### PR TITLE
BUG: Schema fix for updated_at in fct_dbt__latest_full_model_executions

### DIFF
--- a/models/schemas.yml
+++ b/models/schemas.yml
@@ -29,7 +29,7 @@ models:
       description: Foreign key to fct_dbt_run_results. The id of the command which resulted in the source artifact's generation.
     - name: compile_started_at
       description: Timestamp of when a model starts to be compiled.
-    - name: query_completed_ats
+    - name: query_completed_at
       description: Timestamp of when a model's SQL is completed
     - name: total_node_runtime
       description: The duration of time in seconds for the model to run. Note that this is _not_ equal to the delta between `compile_started_at` and `query_completed_at` since it includes extra tasks performed by dbt.


### PR DESCRIPTION
**Expected:**
Running `dbt run -m dbt_artifacts` will succeed.

**Actual:**
When running `dbt run -m dbt_artifacts` a failure occurs due to an incorrect naming in the schemas.yml file for fct_dbt__latest_full_model_executions
![image](https://user-images.githubusercontent.com/1482817/112318587-94346c00-8c83-11eb-82be-744ce8a4fe65.png)

Once renaming the schema everything runs as expected.