### PR TITLE
Capturing exposures data

### DIFF
--- a/models/fct_dbt__exposures_updates.sql
+++ b/models/fct_dbt__exposures_updates.sql
@@ -1,0 +1,35 @@
+with model_updates as (
+    select 
+        max(query_completed_at) as latest_update,
+        node_id
+    from {{ ref('fct_dbt__model_executions') }}
+    group by node_id
+),
+
+exposures as (
+    select
+        artifact_generated_at as latest_generation,
+        node_id,
+        name,
+        type,
+        owner,
+        maturity,
+        package_name,
+        output_feeds
+    from {{ ref('dim_dbt__exposures') }}
+    where artifact_generated_at = (select max(artifact_generated_at) from {{ ref('dim_dbt__exposures') }})
+)
+
+select 
+    e.latest_generation,
+    e.node_id,
+    e.name, 
+    e.type,
+    e.owner,
+    e.maturity,
+    e.package_name,
+    e.output_feeds,
+    latest_update as feed_latest_update
+from exposures e
+left join model_updates m
+on m.node_id = e.output_feeds

--- a/models/fct_dbt__exposures_updates.sql
+++ b/models/fct_dbt__exposures_updates.sql
@@ -1,12 +1,27 @@
-with model_updates as (
+with model_executions as (
+
+    select * from {{ ref('fct_dbt__model_executions') }}
+
+),
+
+exposures_record as (
+
+    select * from {{ ref('dim_dbt__exposures') }}
+
+)
+
+model_updates as (
+
     select 
         max(query_completed_at) as latest_update,
         node_id
-    from {{ ref('fct_dbt__model_executions') }}
+    from model_executions
     group by node_id
+
 ),
 
-exposures as (
+exposures_latest as (
+
     select
         artifact_generated_at as latest_generation,
         node_id,
@@ -16,20 +31,27 @@ exposures as (
         maturity,
         package_name,
         output_feeds
-    from {{ ref('dim_dbt__exposures') }}
-    where artifact_generated_at = (select max(artifact_generated_at) from {{ ref('dim_dbt__exposures') }})
+    from exposures_record
+    where artifact_generated_at = (select max(artifact_generated_at) from exposures_record)
+
+),
+
+exposures_updates as (
+
+    select 
+        e.latest_generation,
+        e.node_id,
+        e.name, 
+        e.type,
+        e.owner,
+        e.maturity,
+        e.package_name,
+        e.output_feeds,
+        latest_update as feed_latest_update
+    from exposures e
+    left join model_updates m
+    on m.node_id = e.output_feeds
+
 )
 
-select 
-    e.latest_generation,
-    e.node_id,
-    e.name, 
-    e.type,
-    e.owner,
-    e.maturity,
-    e.package_name,
-    e.output_feeds,
-    latest_update as feed_latest_update
-from exposures e
-left join model_updates m
-on m.node_id = e.output_feeds
+select * from exposures_updates

--- a/models/incremental/dim_dbt__exposures.sql
+++ b/models/incremental/dim_dbt__exposures.sql
@@ -1,0 +1,44 @@
+{{ 
+  config(
+    materialized='incremental', 
+    unique_key='manifest_model_id'
+    ) 
+}}
+
+with dbt_models as (
+
+    select * from {{ ref('stg_dbt__exposures') }}
+
+),
+
+dbt_models_incremental as (
+
+    select *
+    from dbt_models
+
+    {% if is_incremental() %}
+    -- this filter will only be applied on an incremental run
+    where artifact_generated_at > (select max(artifact_generated_at) from {{ this }})
+    {% endif %}
+
+),
+
+fields as (
+
+     select 
+        t.manifest_model_id,
+        t.command_invocation_id,
+        t.artifact_generated_at,
+        t.node_id,
+        t.name,
+        t.type,
+        t.owner,
+        t.maturity,
+        f.value::string as output_feeds,
+        t.package_name
+    from dbt_models_incremental t,
+    lateral flatten(input => depends_on_nodes) f
+
+)
+
+select * from fields

--- a/models/staging/stg_dbt__exposures.sql
+++ b/models/staging/stg_dbt__exposures.sql
@@ -1,0 +1,52 @@
+with base as (
+
+    select *
+    from {{ ref('stg_dbt__artifacts') }}
+
+),
+
+manifests as (
+
+    select *
+    from base
+    where artifact_type = 'manifest.json'
+
+),
+
+flatten as (
+
+    select
+        command_invocation_id,
+        generated_at as artifact_generated_at,
+        node.key as node_id,
+        node.value:name::string as name,
+        to_array(node.value:depends_on:nodes) as depends_on_nodes,
+        to_array(node.value:sources:nodes) as depends_on_sources,
+        node.value:type::string as type,
+        node.value:owner:name::string as owner,
+        node.value:maturity::string as maturity,
+        node.value:package_name::string as package_name
+    from manifests,
+    lateral flatten(input => data:exposures) as node
+
+),
+
+surrogate_key as (
+
+    select
+        {{ dbt_utils.surrogate_key(['command_invocation_id', 'node_id']) }} as manifest_model_id,
+        command_invocation_id,
+        artifact_generated_at,
+        node_id,
+        name,
+        depends_on_nodes,
+        depends_on_sources,
+        type,
+        owner,
+        maturity,
+        package_name
+    from flatten
+
+)
+
+select * from surrogate_key


### PR DESCRIPTION
Three models to capture exposures data from the manifest.json:
- a staging model extracting metadata about exposures from manifest.json (STG_DBT__EXPOSURES),
- a dimension model expanding exposure-model relations into separate rows (DIM_DBT__EXPOSURES),
- a fact model joining exposures and latest update times of each model feeding them (FCT_DBT__EXPOSURES_UPDATES).