### PR TITLE
Make Env Keys Model Deterministic

### DIFF
--- a/models/incremental/fct_dbt__run_results.sql
+++ b/models/incremental/fct_dbt__run_results.sql
@@ -34,7 +34,7 @@ fields as (
         was_full_refresh
 
         {% if env_keys %}
-        {% for key in sorted(env_keys) %}
+        {% for key in env_keys|sort %}
         ,env:{{ key }} as env_{{ key }}
         {% endfor %}
         {% endif %}

--- a/models/incremental/fct_dbt__run_results.sql
+++ b/models/incremental/fct_dbt__run_results.sql
@@ -34,6 +34,7 @@ fields as (
         was_full_refresh
 
         {% if env_keys %}
+        -- Environment keys are sorted for determinism.
         {% for key in env_keys|sort %}
         ,env:{{ key }} as env_{{ key }}
         {% endfor %}

--- a/models/incremental/fct_dbt__run_results.sql
+++ b/models/incremental/fct_dbt__run_results.sql
@@ -34,7 +34,7 @@ fields as (
         was_full_refresh
 
         {% if env_keys %}
-        {% for key in env_keys %}
+        {% for key in sorted(env_keys) %}
         ,env:{{ key }} as env_{{ key }}
         {% endfor %}
         {% endif %}

--- a/models/staging/stg_dbt__run_results_env_keys.sql
+++ b/models/staging/stg_dbt__run_results_env_keys.sql
@@ -27,6 +27,8 @@ env_keys as (
         distinct(env.key)
     from dbt_run,
     lateral flatten(input => data:metadata:env) as env
+    -- Sort results to ensure things are deterministic
+    order by 1
 
 )
 


### PR DESCRIPTION
This PR sorts the results of the `stg_dbt__run_results_env_keys` model so that the compiled sql is the same on consecutive runs. This is important for deployment introspection.