### PR TITLE
Add `fact_dbt__test_executions` to list of models

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Models included:
 - `fct_dbt__latest_full_model_executions`
 - `fct_dbt__critical_path`
 - `fct_dbt_run_results`
+- `fact_dbt__test_executions`
 
 The critical path model determines the slowest route through your DAG, which provides you with the information needed to make a targeted effort to reducing `dbt run` times. For example:
 


### PR DESCRIPTION
Today I was helping a team with dbt and they were looking for a way to analyze tests in a dbt project. Upon digging into `dbt_artifacts`, I noticed that #28 added an additional table `fact_dbt__test_executions`! So this PR highlights this table in the docs.

Also, should #26 now be closed? Thanks!