### PR TITLE
Add default for run result env keys column values

### DIFF
--- a/models/incremental/fct_dbt__run_results.sql
+++ b/models/incremental/fct_dbt__run_results.sql
@@ -1,6 +1,6 @@
 {{ config( materialized='incremental', unique_key='command_invocation_id' ) }}
 
-{% set env_keys = dbt_utils.get_column_values(table=ref('stg_dbt__run_results_env_keys'), column='key') %}
+{% set env_keys = dbt_utils.get_column_values(table=ref('stg_dbt__run_results_env_keys'), column='key', default=[]) %}
 
 with run_results as (
 


### PR DESCRIPTION
As part of a CI check I run `dbt compile` but I get an error:
```
In get_column_values(): relation staging.dbt_artifacts.stg_dbt__run_results_env_keys does not exist and no default value was provided.
```
Although the docs for `get_column_values` state that the default is `[]` the default in the code is actually None ([code](https://github.com/fishtown-analytics/dbt-utils/blob/master/macros/sql/get_column_values.sql#L5)). As such the code can't be compiled if the table doesn't exist.