### PR TITLE
[0.5.0] Support dbt-labs/dbt_utils v0.7.0

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'dbt_artifacts'
-version: '0.1.0'
+version: '0.5.0'
 config-version: 2
 require-dbt-version: ">=0.19.0"
 

--- a/integration_tests/profiles.yml
+++ b/integration_tests/profiles.yml
@@ -17,5 +17,5 @@ dbt_artifacts_integration_tests:
       role: "{{ env_var('SNOWFLAKE_TEST_ROLE') }}"
       database: "{{ env_var('SNOWFLAKE_TEST_DATABASE') }}"
       warehouse: "{{ env_var('SNOWFLAKE_TEST_WAREHOUSE') }}"
-      schema: codegen_integration_tests_snowflake
+      schema: dbt_artifacts_integration_tests_snowflake
       threads: 1

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
-  - package: fishtown-analytics/dbt_utils
-    version: [">=0.6.0", "<0.7.0"]
+  - package: dbt-labs/dbt_utils
+    version: [">=0.6.0", "<0.8.0"]


### PR DESCRIPTION
- Bump the upper bound on `dbt_utils` to `<0.8.0`, to support dbt-utils v0.7.0 (which is required for use with dbt v0.20.0)
- ❗ Update the dependency from `fishtown-analytics/dbt_utils` to `dbt-labs/dbt_utils`. This is a breaking-ish change
(https://discourse.getdbt.com/t/packages-dbt-labs-in-the-dbt-hub/2711) if users have other packages that install / depend on `fishtown-analytics/dbt_utils`. To avoid bad outcomes, I think this should require a minor version bump.

For the sake of clarity, we could choose to make a stronger delineation and have v0.5.0 of this package require `dbt>=0.20.0` and `dbt-utils>=0.7.0`. It's not strictly required; someone could use v0.5.0 with dbt v0.19.0, so long as they pin `dbt-labs/dbt_utils v0.6.6` and don't have another package that requires it as `fishtown-analytics/dbt_utils`.