### PR TITLE
require dbt >=0.20.0

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 name: 'dbt_artifacts'
 version: '0.5.0'
 config-version: 2
-require-dbt-version: ">=0.19.0"
+require-dbt-version: ">=0.20.0"
 
 models:
   dbt_artifacts:


### PR DESCRIPTION
Follow on from #41. Require dbt >=0.20.0 for version 0.5.0