### PR TITLE
Fix for null run times

### DIFF
--- a/models/fct_dbt__critical_path.sql
+++ b/models/fct_dbt__critical_path.sql
@@ -165,7 +165,7 @@ search_path (node_ids, total_time) as (
     union all
     select
         array_cat(to_array(all_needed_dependencies.depends_on_node_id), search_path.node_ids) as node_ids,
-        all_needed_dependencies.total_node_runtime + search_path.total_time
+        coalesce(all_needed_dependencies.total_node_runtime, 0) + search_path.total_time
     from search_path
     left join all_needed_dependencies
     where get(search_path.node_ids, 0) = all_needed_dependencies.node_id


### PR DESCRIPTION
We were trying to run critical path model for our dbt stack and figured that ephemeral models can have null values as run times which when added with other model run times result in NULL total_runtime for the whole path. 

This showed an incorrect critical path for us which showed 2 minutes vs 4 hours (actual)

The model that we are seeing this issue comes from a snowplow package **model.snowplow.snowplow_base_events**  and might impact for other teams using this artifacts package.

As per the code, it looks like this condition was handled for anchor CTE but not handled in all_needed_dependencies CTE. This PR adds in a coalesce to make the run time 0 if we get a NULL value from all_needed_dependencies CTE.

Happy to share more information if needed. Thanks 