### PR TITLE
Use inner join to accommodate deselected models

### DIFF
--- a/models/fct_dbt__critical_path.sql
+++ b/models/fct_dbt__critical_path.sql
@@ -68,7 +68,8 @@ model_dependencies_with_total_node_runtime as (
         latest_executions.total_node_runtime,
         depends_on_node_id
     from node_dependencies_deduped
-    left join latest_executions on node_dependencies_deduped.node_id = latest_executions.node_id
+    -- Inner join to accomodate runs which exclude some models
+    inner join latest_executions on node_dependencies_deduped.node_id = latest_executions.node_id
     where depends_on_node_type = 'model'
 
 ),


### PR DESCRIPTION
Where the latest run uses a selector, the current `fct_dbt__critical_path.sql` output is incorrect. Switching to an inner join resolves the issue.