### PR TITLE
Handle incremental tables being empty

### DIFF
--- a/models/fct_dbt__exposures_updates.sql
+++ b/models/fct_dbt__exposures_updates.sql
@@ -33,7 +33,7 @@ exposures_latest as (
         package_name,
         output_feeds
     from exposures_record
-    where artifact_generated_at = (select ifnull(max(artifact_generated_at), '1970-01-01 00:00:00 +0000') from exposures_record)
+    where artifact_generated_at = (select max(artifact_generated_at) from exposures_record)
 
 ),
 

--- a/models/fct_dbt__exposures_updates.sql
+++ b/models/fct_dbt__exposures_updates.sql
@@ -33,7 +33,7 @@ exposures_latest as (
         package_name,
         output_feeds
     from exposures_record
-    where artifact_generated_at = (select max(artifact_generated_at) from exposures_record)
+    where artifact_generated_at = (select ifnull(max(artifact_generated_at), '1970-01-01 00:00:00 +0000') from exposures_record)
 
 ),
 

--- a/models/incremental/dim_dbt__exposures.sql
+++ b/models/incremental/dim_dbt__exposures.sql
@@ -18,7 +18,7 @@ dbt_models_incremental as (
 
     {% if is_incremental() %}
     -- this filter will only be applied on an incremental run
-    where artifact_generated_at > (select max(artifact_generated_at) from {{ this }})
+    where artifact_generated_at > (select ifnull(max(artifact_generated_at), '1970-01-01 00:00:00 +0000') from {{ this }})
     {% endif %}
 
 ),

--- a/models/incremental/dim_dbt__models.sql
+++ b/models/incremental/dim_dbt__models.sql
@@ -13,7 +13,7 @@ dbt_models_incremental as (
 
     {% if is_incremental() %}
     -- this filter will only be applied on an incremental run
-    where artifact_generated_at > (select max(artifact_generated_at) from {{ this }})
+    where artifact_generated_at > (select ifnull(max(artifact_generated_at), '1970-01-01 00:00:00 +0000') from {{ this }})
     {% endif %}
 
 ),

--- a/models/incremental/dim_dbt__sources.sql
+++ b/models/incremental/dim_dbt__sources.sql
@@ -13,7 +13,7 @@ dbt_sources_incremental as (
 
     {% if is_incremental() %}
     -- this filter will only be applied on an incremental run
-    where artifact_generated_at > (select max(artifact_generated_at) from {{ this }})
+    where artifact_generated_at > (select ifnull(max(artifact_generated_at), '1970-01-01 00:00:00 +0000') from {{ this }})
     {% endif %}
 
 ),

--- a/models/incremental/fct_dbt__model_executions.sql
+++ b/models/incremental/fct_dbt__model_executions.sql
@@ -21,7 +21,7 @@ model_executions_incremental as (
 
     {% if is_incremental() %}
     -- this filter will only be applied on an incremental run
-    where artifact_generated_at > (select max(artifact_generated_at) from {{ this }})
+    where artifact_generated_at > (select ifnull(max(artifact_generated_at), '1970-01-01 00:00:00 +0000') from {{ this }})
     {% endif %}
 
 ),

--- a/models/incremental/fct_dbt__run_results.sql
+++ b/models/incremental/fct_dbt__run_results.sql
@@ -16,7 +16,7 @@ incremental_run_results as (
 
     {% if is_incremental() %}
     -- this filter will only be applied on an incremental run
-    where artifact_generated_at > (select max(artifact_generated_at) from {{ this }})
+    where artifact_generated_at > (select ifnull(max(artifact_generated_at), '1970-01-01 00:00:00 +0000') from {{ this }})
     {% endif %}
 
 ),

--- a/models/incremental/fct_dbt__test_executions.sql
+++ b/models/incremental/fct_dbt__test_executions.sql
@@ -14,7 +14,7 @@ model_executions_incremental as (
 
     {% if is_incremental() %}
     -- this filter will only be applied on an incremental run
-    where artifact_generated_at > (select max(artifact_generated_at) from {{ this }})
+    where artifact_generated_at > (select ifnull(max(artifact_generated_at), '1970-01-01 00:00:00 +0000') from {{ this }})
     {% endif %}
 
 ),

--- a/models/incremental/int_dbt__model_executions.sql
+++ b/models/incremental/int_dbt__model_executions.sql
@@ -14,7 +14,7 @@ model_executions_incremental as (
 
     {% if is_incremental() %}
     -- this filter will only be applied on an incremental run
-    where artifact_generated_at > (select max(artifact_generated_at) from {{ this }})
+    where artifact_generated_at > (select ifnull(max(artifact_generated_at), '1970-01-01 00:00:00 +0000') from {{ this }})
     {% endif %}
 
 ),


### PR DESCRIPTION
If the incremental table is empty, ie: `dim_dbt__models`, then `max(artifact-generated_at)` will be `NULL`, which means the `dbt_models_incremental` CTE will return 0 rows.

This fix is based on the work that @timothyjang123 did in the following [issue](https://github.com/brooklyn-data/dbt_artifacts/issues/64).

Notes:

1) We weren't sure how to run the `integration_tests` for the `dbt_artifacts` package in isolation, but we are using this fork in our dbt project and it is working successfully.  If there is something we should do to verify our change doesn't break anything with the package in general, we'd be happy todo that.

2) This fix works, but the first time you run it `dbt test` might fail.  The issue in more detail: In our project, we've run `dbt run` several times, so the base `artifacts` table has several runs in it.  If the `max(artifact-generated_at)` is `NULL` and the query falls back to the jan-1-1970 date, then the `dbt_models_incremental` will return rows for several runs.  This means the `unique_fct_dbt__critical_path_node_id`, `unique_fct_dbt__latest_full_model_executions_node_id`, and `unique_fct_dbt__model_executions_model_execution_id` will fail because the count on index will be greater then 1.  I'm not sure if this means that there is a better fix possible.  But I thought it'd be good to open up the PR as-is, as a jumping off point.

