### PR TITLE
Add ability to run forked PRs with secrets once approved

### DIFF
--- a/.github/workflows/github_actions_ci.yml
+++ b/.github/workflows/github_actions_ci.yml
@@ -3,7 +3,9 @@ name: dbt_artifacts_ci
 # triggers for the workflow
 on:
   workflow_dispatch:
-  pull_request:
+  # all PRs, important to note that `pull_request_target` workflows
+  # will run in the context of the target branch of a PR
+  pull_request_target:
   push:
     branches:
       - main
@@ -21,7 +23,9 @@ env:
 jobs:
   ci_workflow:
     runs-on: ubuntu-latest
-    
+    environment:
+      name: Approve Integration Tests
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
Adds the ability for CI checks on pull requests from forked repositories to run with the repository secrets, once approved.

Follows https://dev.to/petrsvihlik/using-environment-protection-rules-to-secure-secrets-when-building-external-forks-with-pullrequesttarget-hci

Tested in https://github.com/brooklyn-data/dbt_artifacts/pull/69