### PR TITLE
Enforce consistency across materialised models.

### DIFF
--- a/models/incremental/dim_dbt__exposures.sql
+++ b/models/incremental/dim_dbt__exposures.sql
@@ -11,14 +11,26 @@ with dbt_exposures as (
 
 ),
 
-dbt_exposures_incremental as (
+run_results as (
 
     select *
+    from {{ ref('fct_dbt__run_results') }}
+
+),
+
+dbt_exposures_incremental as (
+
+    select dbt_exposures.*
     from dbt_exposures
+    -- Inner join with run results to enforce consistency and avoid race conditions.
+    -- https://github.com/brooklyn-data/dbt_artifacts/issues/75
+    inner join run_results on
+        dbt_exposures.command_invocation_id = run_results.command_invocation_id
+        or dbt_exposures.dbt_cloud_run_id = run_results.dbt_cloud_run_id
 
     {% if is_incremental() %}
         -- this filter will only be applied on an incremental run
-        where artifact_generated_at > (select max(artifact_generated_at) from {{ this }})
+        where dbt_exposures.artifact_generated_at > (select max(artifact_generated_at) from {{ this }})
     {% endif %}
 
 ),

--- a/models/incremental/dim_dbt__models.sql
+++ b/models/incremental/dim_dbt__models.sql
@@ -6,14 +6,26 @@ with dbt_models as (
 
 ),
 
-dbt_models_incremental as (
+run_results as (
 
     select *
+    from {{ ref('fct_dbt__run_results') }}
+
+),
+
+dbt_models_incremental as (
+
+    select dbt_models.*
     from dbt_models
+    -- Inner join with run results to enforce consistency and avoid race conditions.
+    -- https://github.com/brooklyn-data/dbt_artifacts/issues/75
+    inner join run_results on
+        dbt_models.command_invocation_id = run_results.command_invocation_id
+        or dbt_models.dbt_cloud_run_id = run_results.dbt_cloud_run_id
 
     {% if is_incremental() %}
         -- this filter will only be applied on an incremental run
-        where coalesce(artifact_generated_at > (select max(artifact_generated_at) from {{ this }}), true)
+        where coalesce(dbt_models.artifact_generated_at > (select max(artifact_generated_at) from {{ this }}), true)
     {% endif %}
 
 ),

--- a/models/incremental/dim_dbt__seeds.sql
+++ b/models/incremental/dim_dbt__seeds.sql
@@ -6,14 +6,26 @@ with dbt_seeds as (
 
 ),
 
-dbt_seeds_incremental as (
+run_results as (
 
     select *
+    from {{ ref('fct_dbt__run_results') }}
+
+),
+
+dbt_seeds_incremental as (
+
+    select dbt_seeds.*
     from dbt_seeds
+    -- Inner join with run results to enforce consistency and avoid race conditions.
+    -- https://github.com/brooklyn-data/dbt_artifacts/issues/75
+    inner join run_results on
+        dbt_seeds.command_invocation_id = run_results.command_invocation_id
+        or dbt_seeds.dbt_cloud_run_id = run_results.dbt_cloud_run_id
 
     {% if is_incremental() %}
         -- this filter will only be applied on an incremental run
-        where artifact_generated_at > (select max(artifact_generated_at) from {{ this }})
+        where dbt_seeds.artifact_generated_at > (select max(artifact_generated_at) from {{ this }})
     {% endif %}
 
 ),

--- a/models/incremental/dim_dbt__sources.sql
+++ b/models/incremental/dim_dbt__sources.sql
@@ -6,14 +6,26 @@ with dbt_sources as (
 
 ),
 
-dbt_sources_incremental as (
+run_results as (
 
     select *
+    from {{ ref('fct_dbt__run_results') }}
+
+),
+
+dbt_sources_incremental as (
+
+    select dbt_sources.*
     from dbt_sources
+    -- Inner join with run results to enforce consistency and avoid race conditions.
+    -- https://github.com/brooklyn-data/dbt_artifacts/issues/75
+    inner join run_results on
+        dbt_sources.command_invocation_id = run_results.command_invocation_id
+        or dbt_sources.dbt_cloud_run_id = run_results.dbt_cloud_run_id
 
     {% if is_incremental() %}
         -- this filter will only be applied on an incremental run
-        where artifact_generated_at > (select max(artifact_generated_at) from {{ this }})
+        where dbt_sources.artifact_generated_at > (select max(artifact_generated_at) from {{ this }})
     {% endif %}
 
 ),

--- a/models/incremental/fct_dbt__seed_executions.sql
+++ b/models/incremental/fct_dbt__seed_executions.sql
@@ -14,14 +14,26 @@ seed_executions as (
 
 ),
 
-seed_executions_incremental as (
+run_results as (
 
     select *
+    from {{ ref('fct_dbt__run_results') }}
+
+),
+
+seed_executions_incremental as (
+
+    select seed_executions.*
     from seed_executions
+    -- Inner join with run results to enforce consistency and avoid race conditions.
+    -- https://github.com/brooklyn-data/dbt_artifacts/issues/75
+    inner join run_results on
+        seed_executions.command_invocation_id = run_results.command_invocation_id
+        or seed_executions.dbt_cloud_run_id = run_results.dbt_cloud_run_id
 
     {% if is_incremental() %}
         -- this filter will only be applied on an incremental run
-        where artifact_generated_at > (select max(artifact_generated_at) from {{ this }})
+        where seed_executions.artifact_generated_at > (select max(artifact_generated_at) from {{ this }})
     {% endif %}
 
 ),

--- a/models/incremental/int_dbt__model_executions.sql
+++ b/models/incremental/int_dbt__model_executions.sql
@@ -11,7 +11,7 @@ model_executions_incremental as (
 
     select *
     from model_executions
-    -- NOTE: Consitency check for this model is done in the fact table not here. See: fct_dbt__model_executions.
+    -- NOTE: Consistency check for this model is done in the fact table not here. See: fct_dbt__model_executions.
 
     {% if is_incremental() %}
         -- this filter will only be applied on an incremental run

--- a/models/incremental/int_dbt__model_executions.sql
+++ b/models/incremental/int_dbt__model_executions.sql
@@ -11,6 +11,7 @@ model_executions_incremental as (
 
     select *
     from model_executions
+    -- NOTE: Consitency check for this model is done in the fact table not here. See: fct_dbt__model_executions.
 
     {% if is_incremental() %}
         -- this filter will only be applied on an incremental run

--- a/models/schemas.yml
+++ b/models/schemas.yml
@@ -102,7 +102,13 @@ models:
       description: The number of rows affected by the model's execution. Always 1 for non-incremental executions.
 
   - name: fct_dbt__run_results
-    description: Metadata for dbt run commands.
+    description: Metadata for dbt run commands. This model is also the point of reference for others
+      in the build process to enforce consistency. Most other models depend on this one to dictate which
+      results have been received. By having this model upstream of the others it is forced to go first
+      and therefore anything picked up by it, can then safely be assumed to exist in the downstream models.
+      Anything which arrives after the materialisation of this model is prevented from appearing in the others
+      using an inner join within the definition of all of them to prevent them showing any facts which
+      arrive during a rebuild.
     columns:
     - name: command_invocation_id
       description: The id of the command which resulted in the source artifact's generation.


### PR DESCRIPTION
This fixes #75 by enforcing consistency between the `run_results` model and all the other incremental models. I've also added a section in the docs to explain what that is and a link to the original issue.

This doesn't yet solve the other issue (#76), but I'll address that in a subsequent PR.