### PR TITLE
quickfix | include build command

### DIFF
--- a/models/staging/stg_dbt__model_executions.sql
+++ b/models/staging/stg_dbt__model_executions.sql
@@ -17,7 +17,7 @@ dbt_run as (
 
     select *
     from run_results
-    where data:args:which = 'run'
+    where data:args:which in ('run', 'build')
 
 ),
 

--- a/models/staging/stg_dbt__run_results.sql
+++ b/models/staging/stg_dbt__run_results.sql
@@ -17,7 +17,7 @@ dbt_run as (
 
     select *
     from run_results
-    where data:args:which in ('run', 'seed', 'snapshot', 'test')
+    where data:args:which in ('run', 'seed', 'snapshot', 'test', 'build')
 
 ),
 

--- a/models/staging/stg_dbt__run_results_env_keys.sql
+++ b/models/staging/stg_dbt__run_results_env_keys.sql
@@ -17,7 +17,7 @@ dbt_run as (
 
     select *
     from run_results
-    where data:args:which = 'run'
+    where data:args:which in ('run', 'build')
 
 ),
 


### PR DESCRIPTION
Related to issue #78.

The model execution and run results staging models omit any dbt artifacts listed in the dbt artifacts table that are from a Build command. Include build into the filtering of these tables so they may pass through to the incremental fact and dimension models.

Only concern here is that snapshots and tests won't get broken out into their respective models being packaged together into a build. May need some future thought there.

This is a quick fix only.