### PR TITLE
Switch fancy quotes to standard ones

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,7 +28,7 @@ rules = L001,L003,L004,L005,L006,L007,L008,L010,L011,L012,L014,L015,L017,L018,L0
 # L027 References should be qualified if select has more than one referenced table/view. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L027
 # L028 References should be consistent in statements with a single table. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L028
 # L030 Inconsistent capitalisation of function names, sqlfluff fix compatible. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L030
-# L035 Do not specify “else null” in a case when statement (redundant), sqlfluff fix compatible. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L035
+# L035 Do not specify "else null" in a case when statement (redundant), sqlfluff fix compatible. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L035
 # L036 Select targets should be on a new line unless there is only one select target, sqlfluff fix compatible. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L036
 # L037 Ambiguous ordering directions for columns in order by clause, sqlfluff fix compatible. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L037
 # L039 Unnecessary whitespace found, sqlfluff fix compatible. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L039


### PR DESCRIPTION
The Mac style quotes in the tox.ini are causing chaos in a windows environment. This fixes that 👍 