### PR TITLE
Set specific stage

### DIFF
--- a/macros/create_artifact_resources.sql
+++ b/macros/create_artifact_resources.sql
@@ -1,7 +1,7 @@
 {% macro create_artifact_resources() %}
 
 {% set src_dbt_artifacts = source('dbt_artifacts', 'artifacts') %}
-{% set artifact_stage = var('dbt_artifacts_stage', 'dbt_artifacts_stage') %}
+{% set artifact_stage = src_dbt_artifacts.database ~ "." ~ {{ src_dbt_artifacts.schema }} ~ "." ~ var('dbt_artifacts_stage', 'dbt_artifacts_stage') %}
 
 {% set src_results = source('dbt_artifacts', 'dbt_run_results') %}
 {% set src_results_nodes = source('dbt_artifacts', 'dbt_run_results_nodes') %}
@@ -15,7 +15,7 @@ file_format = (type = json);
 {% endset %}
 
 {% set create_v2_stage_query %}
-create stage if not exists {{ src_dbt_artifacts.database }}.{{ src_dbt_artifacts.schema }}.{{ artifact_stage }}
+create stage if not exists {{ artifact_stage }}
 file_format = (type = json);
 {% endset %}
 

--- a/macros/create_artifact_resources.sql
+++ b/macros/create_artifact_resources.sql
@@ -15,7 +15,7 @@ file_format = (type = json);
 {% endset %}
 
 {% set create_v2_stage_query %}
-create stage if not exists {{ artifact_stage }}
+create stage if not exists {{ src_dbt_artifacts.database }}.{{ src_dbt_artifacts.schema }}.{{ artifact_stage }}
 file_format = (type = json);
 {% endset %}
 

--- a/macros/create_artifact_resources.sql
+++ b/macros/create_artifact_resources.sql
@@ -1,7 +1,7 @@
 {% macro create_artifact_resources() %}
 
 {% set src_dbt_artifacts = source('dbt_artifacts', 'artifacts') %}
-{% set artifact_stage = src_dbt_artifacts.database ~ "." ~ {{ src_dbt_artifacts.schema }} ~ "." ~ var('dbt_artifacts_stage', 'dbt_artifacts_stage') %}
+{% set artifact_stage = src_dbt_artifacts.database ~ "." ~ src_dbt_artifacts.schema ~ "." ~ var('dbt_artifacts_stage', 'dbt_artifacts_stage') %}
 
 {% set src_results = source('dbt_artifacts', 'dbt_run_results') %}
 {% set src_results_nodes = source('dbt_artifacts', 'dbt_run_results_nodes') %}

--- a/macros/upload_artifacts_v2.sql
+++ b/macros/upload_artifacts_v2.sql
@@ -3,7 +3,7 @@
 {# All main dbt commands produce both files and so set both by default #}
 {% set filenames = ['manifest', 'run_results'] %}
 
-{% set artifact_stage = var('dbt_artifacts_stage', 'dbt_artifacts_stage') %}
+{% set artifact_stage = src_dbt_artifacts.database ~ "." ~ src_dbt_artifacts.schema ~ "." ~ var('dbt_artifacts_stage', 'dbt_artifacts_stage') %}
 
 {% set src_results = source('dbt_artifacts', 'dbt_run_results') %}
 {% set src_results_nodes = source('dbt_artifacts', 'dbt_run_results_nodes') %}

--- a/macros/upload_artifacts_v2.sql
+++ b/macros/upload_artifacts_v2.sql
@@ -3,6 +3,7 @@
 {# All main dbt commands produce both files and so set both by default #}
 {% set filenames = ['manifest', 'run_results'] %}
 
+{% set src_dbt_artifacts = source('dbt_artifacts', 'artifacts') %}
 {% set artifact_stage = src_dbt_artifacts.database ~ "." ~ src_dbt_artifacts.schema ~ "." ~ var('dbt_artifacts_stage', 'dbt_artifacts_stage') %}
 
 {% set src_results = source('dbt_artifacts', 'dbt_run_results') %}


### PR DESCRIPTION
#84 moved from defining the stage as a source to defining it as a var. That means that it doesn't automatically include a schema and database. This extends both the create and upload scripts to use the schema and database from the v1 schema as the location for the new stage.