### PR TITLE
Prevent null latest models

### DIFF
--- a/models/fct_dbt__latest_full_model_executions.sql
+++ b/models/fct_dbt__latest_full_model_executions.sql
@@ -29,9 +29,9 @@ latest_full as (
     inner join model_execution_counts on
         run_results.artifact_run_id = model_execution_counts.artifact_run_id
     where run_results.execution_command = 'run'
-    and run_results.selected_models is null
-    and run_results.was_full_refresh = false
-    and model_execution_counts.executed_models >= 1
+        and run_results.selected_models is null
+        and run_results.was_full_refresh = false
+        and model_execution_counts.executed_models >= 1
     order by run_results.artifact_generated_at desc
     limit 1
 

--- a/models/fct_dbt__latest_full_model_executions.sql
+++ b/models/fct_dbt__latest_full_model_executions.sql
@@ -12,11 +12,26 @@ model_executions as (
 
 ),
 
+model_execution_counts as (
+
+    select
+        artifact_run_id,
+        count(*) as executed_models
+    from model_executions
+    group by artifact_run_id
+
+),
+
 latest_full as (
 
     select *
     from run_results
-    where execution_command = 'run' and selected_models is null and was_full_refresh = false
+    inner join model_execution_counts on
+        run_results.artifact_run_id = model_execution_counts.artifact_run_id
+    where execution_command = 'run'
+    and selected_models is null
+    and was_full_refresh = false
+    and executed_models >= 1
     order by artifact_generated_at desc
     limit 1
 

--- a/models/fct_dbt__latest_full_model_executions.sql
+++ b/models/fct_dbt__latest_full_model_executions.sql
@@ -28,11 +28,11 @@ latest_full as (
     from run_results
     inner join model_execution_counts on
         run_results.artifact_run_id = model_execution_counts.artifact_run_id
-    where execution_command = 'run'
-    and selected_models is null
-    and was_full_refresh = false
-    and executed_models >= 1
-    order by artifact_generated_at desc
+    where run_results.execution_command = 'run'
+    and run_results.selected_models is null
+    and run_results.was_full_refresh = false
+    and model_execution_counts.executed_models >= 1
+    order by run_results.artifact_generated_at desc
     limit 1
 
 ),

--- a/models/fct_dbt__latest_full_model_executions.sql
+++ b/models/fct_dbt__latest_full_model_executions.sql
@@ -28,7 +28,7 @@ latest_full as (
     from run_results
     inner join model_execution_counts on
         run_results.artifact_run_id = model_execution_counts.artifact_run_id
-    where run_results.execution_command = 'run'
+    where run_results.execution_command in ('run', 'build')
         and run_results.selected_models is null
         and run_results.was_full_refresh = false
         and model_execution_counts.executed_models >= 1

--- a/models/fct_dbt__latest_full_model_executions.sql
+++ b/models/fct_dbt__latest_full_model_executions.sql
@@ -24,7 +24,7 @@ model_execution_counts as (
 
 latest_full as (
 
-    select *
+    select run_results.*
     from run_results
     inner join model_execution_counts on
         run_results.artifact_run_id = model_execution_counts.artifact_run_id


### PR DESCRIPTION
This solves an intermittent error we were getting on `not_null_fct_dbt__latest_full_model_executions_node_id`, where if results were uploaded without a manifest for some reason - that this tests would fail because where there are run results, but no model executions.