### PR TITLE
feat: add --select flag data

### DIFF
--- a/macros/upload_artifacts_v2.sql
+++ b/macros/upload_artifacts_v2.sql
@@ -38,7 +38,7 @@
             elapsed_time,
             args:which::string as execution_command,
             coalesce(args:full_refresh, 'false')::boolean as was_full_refresh,
-            args:models as selected_models,
+            coalesce(args:models, args:select) as selected_models,
             args:target::string as target,
             metadata,
             args

--- a/models/staging/stg_dbt__run_results.sql
+++ b/models/staging/stg_dbt__run_results.sql
@@ -33,7 +33,7 @@ fields as (
         data:elapsed_time::float as elapsed_time,
         data:args:which::string as execution_command,
         coalesce(data:args:full_refresh, 'false')::boolean as was_full_refresh,
-        data:args:models as selected_models,
+        coalesce(data:args:models, data:args:select) as selected_models,
         data:args:target::string as target
     from run_results
 


### PR DESCRIPTION
## Description

stg_dbt__run_results show models args as selected_models column, but since moving to dbt1, the models flag has been deprecated and the select flag is being used instead. It would be great to have the information from the select flag available in the model.




## Issue Link
https://github.com/brooklyn-data/dbt_artifacts/issues/91