### PR TITLE
Handle empty models when running incrementally by coalescing with true

### DIFF
--- a/models/incremental/dim_dbt__exposures.sql
+++ b/models/incremental/dim_dbt__exposures.sql
@@ -19,7 +19,7 @@ dbt_exposures_incremental as (
 
         {% if is_incremental() %}
             -- this filter will only be applied on an incremental run
-            and artifact_generated_at > (select max(artifact_generated_at) from {{ this }})
+            and coalesce(artifact_generated_at > (select max(artifact_generated_at) from {{ this }}), true)
         {% endif %}
 
 ),

--- a/models/incremental/dim_dbt__seeds.sql
+++ b/models/incremental/dim_dbt__seeds.sql
@@ -14,7 +14,7 @@ dbt_seeds_incremental as (
 
         {% if is_incremental() %}
             -- this filter will only be applied on an incremental run
-            and artifact_generated_at > (select max(artifact_generated_at) from {{ this }})
+            and coalesce(artifact_generated_at > (select max(artifact_generated_at) from {{ this }}), true)
         {% endif %}
 
 ),

--- a/models/incremental/dim_dbt__snapshots.sql
+++ b/models/incremental/dim_dbt__snapshots.sql
@@ -14,7 +14,7 @@ dbt_snapshots_incremental as (
 
         {% if is_incremental() %}
             -- this filter will only be applied on an incremental run
-            and artifact_generated_at > (select max(artifact_generated_at) from {{ this }})
+            and coalesce(artifact_generated_at > (select max(artifact_generated_at) from {{ this }}), true)
         {% endif %}
 
 ),

--- a/models/incremental/dim_dbt__sources.sql
+++ b/models/incremental/dim_dbt__sources.sql
@@ -14,7 +14,7 @@ dbt_sources_incremental as (
 
         {% if is_incremental() %}
             -- this filter will only be applied on an incremental run
-            and artifact_generated_at > (select max(artifact_generated_at) from {{ this }})
+            and coalesce(artifact_generated_at > (select max(artifact_generated_at) from {{ this }}), true)
         {% endif %}
 
 ),

--- a/models/incremental/dim_dbt__tests.sql
+++ b/models/incremental/dim_dbt__tests.sql
@@ -14,7 +14,7 @@ dbt_tests_incremental as (
 
         {% if is_incremental() %}
             -- this filter will only be applied on an incremental run
-            and artifact_generated_at > (select max(artifact_generated_at) from {{ this }})
+            and coalesce(artifact_generated_at > (select max(artifact_generated_at) from {{ this }}), true)
         {% endif %}
 
 ),

--- a/models/incremental/fct_dbt__model_executions.sql
+++ b/models/incremental/fct_dbt__model_executions.sql
@@ -21,7 +21,7 @@ model_executions_incremental as (
 
     {% if is_incremental() %}
         -- this filter will only be applied on an incremental run
-        where artifact_generated_at > (select max(artifact_generated_at) from {{ this }})
+        where coalesce(artifact_generated_at > (select max(artifact_generated_at) from {{ this }}), true)
     {% endif %}
 
 ),

--- a/models/incremental/fct_dbt__run_results.sql
+++ b/models/incremental/fct_dbt__run_results.sql
@@ -16,7 +16,7 @@ incremental_run_results as (
 
     {% if is_incremental() %}
     -- this filter will only be applied on an incremental run
-    where artifact_generated_at > (select max(artifact_generated_at) from {{ this }})
+    where coalesce(artifact_generated_at > (select max(artifact_generated_at) from {{ this }}), true)
     {% endif %}
 
 ),

--- a/models/incremental/fct_dbt__seed_executions.sql
+++ b/models/incremental/fct_dbt__seed_executions.sql
@@ -22,7 +22,7 @@ seed_executions_incremental as (
 
         {% if is_incremental() %}
             -- this filter will only be applied on an incremental run
-            and artifact_generated_at > (select max(artifact_generated_at) from {{ this }})
+            and coalesce(artifact_generated_at > (select max(artifact_generated_at) from {{ this }}), true)
         {% endif %}
 
 ),

--- a/models/incremental/fct_dbt__snapshot_executions.sql
+++ b/models/incremental/fct_dbt__snapshot_executions.sql
@@ -22,7 +22,7 @@ snapshot_executions_incremental as (
 
         {% if is_incremental() %}
             -- this filter will only be applied on an incremental run
-            and artifact_generated_at > (select max(artifact_generated_at) from {{ this }})
+            and coalesce(artifact_generated_at > (select max(artifact_generated_at) from {{ this }}), true)
         {% endif %}
 
 ),

--- a/models/incremental/fct_dbt__test_executions.sql
+++ b/models/incremental/fct_dbt__test_executions.sql
@@ -15,7 +15,7 @@ test_executions_incremental as (
 
         {% if is_incremental() %}
             -- this filter will only be applied on an incremental run
-            and artifact_generated_at > (select max(artifact_generated_at) from {{ this }})
+            and coalesce(artifact_generated_at > (select max(artifact_generated_at) from {{ this }}), true)
         {% endif %}
 
 ),

--- a/models/incremental/int_dbt__model_executions.sql
+++ b/models/incremental/int_dbt__model_executions.sql
@@ -15,7 +15,7 @@ model_executions_incremental as (
 
         {% if is_incremental() %}
             -- this filter will only be applied on an incremental run
-            and artifact_generated_at > (select max(artifact_generated_at) from {{ this }})
+            and coalesce(artifact_generated_at > (select max(artifact_generated_at) from {{ this }}), true)
         {% endif %}
 
 ),


### PR DESCRIPTION
Resolves https://github.com/brooklyn-data/dbt_artifacts/issues/64

Where the tables were empty, the incremental logic was returning a `null` value and so pulling through no new rows. Coalescing the incremental logic with a 'true' value resolves this.