### PR TITLE
Run specific stages

### DIFF
--- a/macros/upload_artifacts.sql
+++ b/macros/upload_artifacts.sql
@@ -4,7 +4,7 @@
 
 {# All uploads are prefixed by the invocation_id in the stage to isolate parallel jobs from one another #}
 {% set remove_query %}
-    remove @{{ src_dbt_artifacts }} pattern='{{ invocation_id }}\/.*\.json.gz';
+    remove @{{ src_dbt_artifacts }} pattern='.*\/{{ invocation_id }}\/.*\.json.gz';
 {% endset %}
 
 {% do log("Clearing existing files from Stage: " ~ remove_query, info=True) %}

--- a/macros/upload_artifacts.sql
+++ b/macros/upload_artifacts.sql
@@ -2,8 +2,9 @@
 
 {% set src_dbt_artifacts = source('dbt_artifacts', 'artifacts') %}
 
+{# All uploads are prefixed by the invocation_id in the stage to isolate parallel jobs from one another #}
 {% set remove_query %}
-    remove @{{ src_dbt_artifacts }} pattern='.*.json.gz';
+    remove @{{ src_dbt_artifacts }} pattern='{{ invocation_id }}\/.*\.json.gz';
 {% endset %}
 
 {% do log("Clearing existing files from Stage: " ~ remove_query, info=True) %}
@@ -14,7 +15,7 @@
     {% set file = filename ~ '.json' %}
 
     {% set put_query %}
-        put file://{{ prefix }}{{ file }} @{{ src_dbt_artifacts }} auto_compress=true;
+        put file://{{ prefix }}{{ file }} @{{ src_dbt_artifacts }}/{{ invocation_id }} auto_compress=true;
     {% endset %}
 
     {% do log("Uploading " ~ file ~ " to Stage: " ~ put_query, info=True) %}

--- a/macros/upload_artifacts_v2.sql
+++ b/macros/upload_artifacts_v2.sql
@@ -12,7 +12,7 @@
 
 {# All uploads are prefixed by the invocation_id in the stage to isolate parallel jobs from one another #}
 {% set remove_query %}
-    remove @{{ artifact_stage }} pattern='{{ invocation_id }}\/.*\.json.gz';
+    remove @{{ artifact_stage }} pattern='.*\/{{ invocation_id }}\/.*\.json.gz';
 {% endset %}
 
 {% set results_query %}

--- a/macros/upload_artifacts_v2.sql
+++ b/macros/upload_artifacts_v2.sql
@@ -10,8 +10,9 @@
 {% set src_results_nodes = source('dbt_artifacts', 'dbt_run_results_nodes') %}
 {% set src_manifest_nodes = source('dbt_artifacts', 'dbt_manifest_nodes') %}
 
+{# All uploads are prefixed by the invocation_id in the stage to isolate parallel jobs from one another #}
 {% set remove_query %}
-    remove @{{ artifact_stage }} pattern='.*.json.gz';
+    remove @{{ artifact_stage }} pattern='{{ invocation_id }}\/.*\.json.gz';
 {% endset %}
 
 {% set results_query %}
@@ -191,7 +192,7 @@
     {% set file = filename ~ '.json' %}
 
     {% set put_query %}
-        put file://{{ prefix }}{{ file }} @{{ artifact_stage }} auto_compress=true;
+        put file://{{ prefix }}{{ file }} @{{ artifact_stage }}/{{ invocation_id }} auto_compress=true;
     {% endset %}
 
     {% do log("Uploading " ~ file ~ " to Stage: " ~ put_query, info=True) %}


### PR DESCRIPTION
Resolves #111 .

This prefixes all artifact uploads with the `invocation_id`. For reasons unknown to me it only works if it's also prefixed with another wildcard. I've tested this and it cleans up nicely after itself.