### PR TITLE
Qualify artifact read paths

### DIFF
--- a/macros/upload_artifacts.sql
+++ b/macros/upload_artifacts.sql
@@ -30,7 +30,7 @@
             $1:metadata:generated_at::timestamp_ntz as generated_at,
             metadata$filename as path,
             regexp_substr(metadata$filename, '([a-z_]+.json)') as artifact_type
-            from  @{{ src_dbt_artifacts }}
+            from  @{{ src_dbt_artifacts }}/{{ invocation_id }}
         ) as new_data
         on old_data.generated_at = new_data.generated_at
         -- NB: No clause for "when matched" - as matching rows should be skipped.

--- a/macros/upload_artifacts_v2.sql
+++ b/macros/upload_artifacts_v2.sql
@@ -25,7 +25,7 @@
                 run_results.$1:metadata as metadata,
                 run_results.$1:args as args,
                 run_results.$1:elapsed_time::float as elapsed_time
-            from @{{ artifact_stage }} as run_results
+            from @{{ artifact_stage }}/{{ invocation_id }} as run_results
 
         )
 
@@ -94,7 +94,7 @@
                 metadata:env:DBT_CLOUD_RUN_ID::int as dbt_cloud_run_id,
                 {{ make_artifact_run_id() }} as artifact_run_id,
                 metadata:generated_at::timestamp_tz as generated_at
-            from @{{ artifact_stage }} as run_results
+            from @{{ artifact_stage }}/{{ invocation_id }} as run_results
 
         )
 
@@ -147,7 +147,7 @@
                 {{ make_artifact_run_id() }} as artifact_run_id,
                 metadata:generated_at::timestamp_tz as generated_at,
                 manifests.$1 as data
-            from @{{ artifact_stage }} as manifests
+            from @{{ artifact_stage }}/{{ invocation_id }} as manifests
 
         )
 


### PR DESCRIPTION
Resolves #111 (again).

We qualified the writes (and removes), but we didn't qualify the reads. I'm still getting errors as a result on the pre-release when multiple jobs step on each others toes.