### PR TITLE
Failures count column in fct_dbt__test_executions

### DIFF
--- a/models/incremental/fct_dbt__test_executions.sql
+++ b/models/incremental/fct_dbt__test_executions.sql
@@ -35,7 +35,8 @@ fields as (
         compile_started_at,
         query_completed_at,
         total_node_runtime,
-        rows_affected
+        rows_affected,
+        failures
     from test_executions_incremental
 
 )

--- a/models/staging/stg_dbt__node_executions.sql
+++ b/models/staging/stg_dbt__node_executions.sql
@@ -59,6 +59,7 @@ surrogate_key as (
         fields.query_completed_at,
         fields.total_node_runtime,
         fields.result_json:adapter_response:rows_affected::int as rows_affected,
+        fields.result_json:failures::int as failures,
         fields.result_json
     from fields
     -- Inner join so that we only represent results for nodes which definitely have a manifest


### PR DESCRIPTION
added failures column to fct_dbt__test_executions and stg_dbt__node_executions models indicating the number of failures for a given test



