### PR TITLE
Remove --no-write-json flags from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,32 +71,31 @@ Snowflake makes it possible to load local files into your warehouse. We've inclu
    names using the variables listed in the Installation section, above.
 
 2. Add [operations](https://docs.getdbt.com/docs/building-a-dbt-project/hooks-operations/#operations)
-   to your production run to load files into your table. The [--no-write-json](https://docs.getdbt.com/reference/global-configs#writing-json-artifacts) flag ensures that no
-   artifacts are overwritten by the run-operation prior to uploading.
+   to your production run to load files into your table.
 
    **V2 Macro**: Use the `upload_dbt_artifacts_v2` macro ([source](macros/upload_artifacts.sql)). Run the macro after `build`, `run`, `test`, `seed` and `snapshot` operations.
    ```txt
    $ dbt build
-   $ dbt --no-write-json run-operation upload_dbt_artifacts_v2
+   $ dbt run-operation upload_dbt_artifacts_v2
    ```
 
    **V1 Macro**: Use the `upload_dbt_artifacts` macro ([source](macros/upload_artifacts.sql)). You'll need
    to specify which files to upload through use of the `--args` flag. Here's an example setup.
    ```txt
    $ dbt seed
-   $ dbt --no-write-json run-operation upload_dbt_artifacts --args '{filenames: [manifest, run_results]}'
+   $ dbt run-operation upload_dbt_artifacts --args '{filenames: [manifest, run_results]}'
 
    $ dbt run
-   $ dbt --no-write-json run-operation upload_dbt_artifacts --args '{filenames: [manifest, run_results]}'
+   $ dbt run-operation upload_dbt_artifacts --args '{filenames: [manifest, run_results]}'
 
    $ dbt test
-   $ dbt --no-write-json run-operation upload_dbt_artifacts --args '{filenames: [run_results]}'
+   $ dbt run-operation upload_dbt_artifacts --args '{filenames: [run_results]}'
 
    $ dbt source snapshot-freshness
-   $ dbt --no-write-json run-operation upload_dbt_artifacts --args '{filenames: [sources]}'
+   $ dbt run-operation upload_dbt_artifacts --args '{filenames: [sources]}'
 
    $ dbt docs generate
-   $ dbt --no-write-json run-operation upload_dbt_artifacts --args '{filenames: [catalog]}'
+   $ dbt run-operation upload_dbt_artifacts --args '{filenames: [catalog]}'
    ```
 
 ### Option 2: Loading cloud storage files [V1 upload method only]


### PR DESCRIPTION
This flag isn't available in dbt Cloud, and isn't needed either as the artifacts are only overwritten once the dbt command has completed running.