### PR TITLE
Feature: Add regex to parse out thread ID

### DIFF
--- a/models/staging/stg_dbt__node_executions.sql
+++ b/models/staging/stg_dbt__node_executions.sql
@@ -52,7 +52,7 @@ surrogate_key as (
         fields.was_full_refresh,
         fields.node_id,
         base_nodes.resource_type,
-        split(fields.result_json:thread_id::string, '-')[1]::integer as thread_id,
+        regexp_substr(split(fields.result_json:thread_id::string, '-')[1], '[0-9]*')::integer as thread_id,
         fields.status,
         fields.result_json:message::string as message,
         fields.compile_started_at,


### PR DESCRIPTION
This PR will resolve https://github.com/brooklyn-data/dbt_artifacts/issues/124 by removing all redundant text from the thread ID