### PR TITLE
First pass at `dim_dbt__current_models`

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ The package currently supports Databricks and Snowflake.
 Models included:
 
 ```
+dim_dbt__current_models
 dim_dbt__exposures
 dim_dbt__models
 dim_dbt__seeds

--- a/models/dim_dbt__current_models.sql
+++ b/models/dim_dbt__current_models.sql
@@ -30,7 +30,7 @@ latest_models_runs as (
         ) as run_idx
     from model_executions
     inner join latest_models on model_executions.node_id = latest_models.node_id
-    where status = 'success'
+    where model_executions.status = 'success'
 ),
 
 latest_model_stats as (

--- a/models/dim_dbt__current_models.sql
+++ b/models/dim_dbt__current_models.sql
@@ -1,0 +1,63 @@
+with base as (
+    select *
+    from {{ ref('stg_dbt__models') }}
+),
+
+model_executions as (
+    select *
+    from {{ ref('stg_dbt__model_executions') }}
+),
+
+latest_models as (
+    /* Retrieves the models present in the most recent run */
+    select *
+    from base
+    where run_started_at = (select max(run_started_at) from base)
+),
+
+latest_models_runs as (
+    /* Retreives all successful run information for the models present in the most
+    recent run and ranks them based on query completion time */
+    select
+        model_executions.node_id
+        , model_executions.was_full_refresh
+        , model_executions.query_completed_at
+        , model_executions.total_node_runtime
+        , model_executions.rows_affected
+        , row_number() over (
+            partition by latest_models.node_id, model_executions.was_full_refresh
+            order by model_executions.query_completed_at desc /* most recent ranked first */
+        ) as run_idx
+    from model_executions
+    inner join latest_models on model_executions.node_id = latest_models.node_id
+    where status = 'success'
+),
+
+latest_model_stats as (
+    select
+        node_id
+        , case when was_full_refresh then query_completed_at end as last_full_run_completed_at
+        , case when was_full_refresh then total_node_runtime end as last_full_run_total_runtime
+        , case when was_full_refresh then rows_affected end as last_full_run_rows_affected
+        , case when not was_full_refresh then query_completed_at end as last_incremental_run_completed_at
+        , case when not was_full_refresh then total_node_runtime end as last_incremental_run_total_runtime
+        , case when not was_full_refresh then rows_affected end as last_incremental_run_rows_affected
+    from latest_models_runs
+    where run_idx = 1
+),
+
+final as (
+    select
+        latest_models.*
+        , latest_model_stats.last_full_run_completed_at
+        , latest_model_stats.last_full_run_total_runtime
+        , latest_model_stats.last_full_run_rows_affected
+        , latest_model_stats.last_incremental_run_completed_at
+        , latest_model_stats.last_incremental_run_total_runtime
+        , latest_model_stats.last_incremental_run_rows_affected
+    from latest_models
+    left join latest_model_stats
+        on latest_models.node_id = latest_model_stats.node_id
+)
+
+select * from final

--- a/models/dim_dbt__current_models.yml
+++ b/models/dim_dbt__current_models.yml
@@ -1,0 +1,42 @@
+version: 2
+
+models:
+- name: dim_dbt__current_models
+  description: Dimension model that contains data about models' most recent successful runs
+  columns:
+  - name: checksum
+    description: '{{ doc("checksum") }}'
+  - name: command_invocation_id
+    description: '{{ doc("command_invocation_id") }}'
+  - name: database
+    description: '{{ doc("database") }}'
+  - name: depends_on_nodes
+    description: '{{ doc("depends_on_nodes") }}'
+  - name: last_full_run_completed_at
+    description: '{{ doc("last_full_run_completed_at") }}'
+  - name: last_full_run_rows_affected
+    description: '{{ doc("last_full_run_rows_affected") }}'
+  - name: last_full_run_total_runtime
+    description: '{{ doc("last_full_run_total_runtime") }}'
+  - name: last_incremental_run_completed_at
+    description: '{{ doc("last_incremental_run_completed_at") }}'
+  - name: last_incremental_run_rows_affected
+    description: '{{ doc("last_incremental_run_rows_affected") }}'
+  - name: last_incremental_run_total_runtime
+    description: '{{ doc("last_incremental_run_total_runtime") }}'
+  - name: materialization
+    description: '{{ doc("materialization") }}'
+  - name: model_execution_id
+    description: '{{ doc("model_execution_id") }}'
+  - name: name
+    description: '{{ doc("name") }}'
+  - name: node_id
+    description: '{{ doc("node_id") }}'
+  - name: package_name
+    description: '{{ doc("package_name") }}'
+  - name: path
+    description: '{{ doc("path") }}'
+  - name: run_started_at
+    description: '{{ doc("run_started_at") }}'
+  - name: schema
+    description: '{{ doc("schema") }}'

--- a/models/dim_dbt__current_models.yml
+++ b/models/dim_dbt__current_models.yml
@@ -12,18 +12,18 @@ models:
     description: '{{ doc("database") }}'
   - name: depends_on_nodes
     description: '{{ doc("depends_on_nodes") }}'
-  - name: last_full_run_completed_at
-    description: '{{ doc("last_full_run_completed_at") }}'
-  - name: last_full_run_rows_affected
-    description: '{{ doc("last_full_run_rows_affected") }}'
-  - name: last_full_run_total_runtime
-    description: '{{ doc("last_full_run_total_runtime") }}'
-  - name: last_incremental_run_completed_at
-    description: '{{ doc("last_incremental_run_completed_at") }}'
-  - name: last_incremental_run_rows_affected
-    description: '{{ doc("last_incremental_run_rows_affected") }}'
-  - name: last_incremental_run_total_runtime
-    description: '{{ doc("last_incremental_run_total_runtime") }}'
+  - name: last_full_refresh_run_completed_at
+    description: '{{ doc("last_full_refresh_run_completed_at") }}'
+  - name: last_full_refresh_run_rows_affected
+    description: '{{ doc("last_full_refresh_run_rows_affected") }}'
+  - name: last_full_refresh_run_total_runtime
+    description: '{{ doc("last_full_refresh_run_total_runtime") }}'
+  - name: last_run_completed_at
+    description: '{{ doc("last_run_completed_at") }}'
+  - name: last_run_rows_affected
+    description: '{{ doc("last_run_rows_affected") }}'
+  - name: last_run_total_runtime
+    description: '{{ doc("last_run_total_runtime") }}'
   - name: materialization
     description: '{{ doc("materialization") }}'
   - name: model_execution_id

--- a/models/docs.md
+++ b/models/docs.md
@@ -316,3 +316,39 @@ Key-value pairs of environment variables to be capture.
 Key-value pairs of project variables to be capture.
 
 {% enddocs %}
+
+{% docs last_full_run_completed_at %}
+
+Timestamp when the node's SQL query completed on the last full (non-incremental) run.
+
+{% enddocs %}
+
+{% docs last_full_run_rows_affected %}
+
+Number of rows affected by the node's last full (non-incremental) run
+
+{% enddocs %}
+
+{% docs last_full_run_total_runtime %}
+
+Total time spent executing the node's last full (non-incremental) run (seconds).
+
+{% enddocs %}
+
+{% docs last_incremental_run_completed_at %}
+
+Timestamp when the node's SQL query completed on the last incremental run.
+
+{% enddocs %}
+
+{% docs last_incremental_run_rows_affected %}
+
+Number of rows affected by the node's last incremental run
+
+{% enddocs %}
+
+{% docs last_incremental_run_total_runtime %}
+
+Total time spent executing the node's last incremental run (seconds).
+
+{% enddocs %}

--- a/models/docs.md
+++ b/models/docs.md
@@ -317,38 +317,38 @@ Key-value pairs of project variables to be capture.
 
 {% enddocs %}
 
-{% docs last_full_run_completed_at %}
+{% docs last_full_refresh_run_completed_at %}
 
 Timestamp when the node's SQL query completed on the last full (non-incremental) run.
 
 {% enddocs %}
 
-{% docs last_full_run_rows_affected %}
+{% docs last_full_refresh_run_rows_affected %}
 
-Number of rows affected by the node's last full (non-incremental) run
+Number of rows affected by the node's last full (non-incremental) run.
 
 {% enddocs %}
 
-{% docs last_full_run_total_runtime %}
+{% docs last_full_refresh_run_total_runtime %}
 
 Total time spent executing the node's last full (non-incremental) run (seconds).
 
 {% enddocs %}
 
-{% docs last_incremental_run_completed_at %}
+{% docs last_run_completed_at %}
 
-Timestamp when the node's SQL query completed on the last incremental run.
-
-{% enddocs %}
-
-{% docs last_incremental_run_rows_affected %}
-
-Number of rows affected by the node's last incremental run
+Timestamp when the node's SQL query completed on the last run.
 
 {% enddocs %}
 
-{% docs last_incremental_run_total_runtime %}
+{% docs last_run_rows_affected %}
 
-Total time spent executing the node's last incremental run (seconds).
+Number of rows affected by the node's last run.
+
+{% enddocs %}
+
+{% docs last_run_total_runtime %}
+
+Total time spent executing the node's last run (seconds).
 
 {% enddocs %}


### PR DESCRIPTION
# Overview
Partially resolves  #137 by adding `dim_dbt__current_models`

## Key Changes
- Adds `dim_dbt__current_models` model and yml file, maintaining the same columns as pre-v1 version
- Adds new model to repo readme.

## Links
- #137 
- Previous version of the model is [here](https://github.com/brooklyn-data/dbt_artifacts/blob/0.8.0/models/schemas.yml)
