### PR TITLE
Disable dbt_artifacts schema creation as option

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The following configuration can be used to specify where the raw data is uploade
 vars:
   dbt_artifacts_database: your_db # optional, default is your target database
   dbt_artifacts_schema: your_schema # optional, default is your target schema
+  dbt_artifacts_create_schema: true|false # optional, set to false if you don't have privileges to create schema, default is true
 
 models:
   ...

--- a/macros/create_dbt_artifacts_tables.sql
+++ b/macros/create_dbt_artifacts_tables.sql
@@ -6,7 +6,9 @@
     {% set database_name = var('dbt_artifacts_database', target.database) %}
     {% endif %}
 
-    {%- do adapter.create_schema(api.Relation.create(database=database_name, schema=var('dbt_artifacts_schema', target.schema))) -%}
+    {%- if var('dbt_artifacts_create_schema', true) -%}
+        {%- do adapter.create_schema(api.Relation.create(database=database_name, schema=var('dbt_artifacts_schema', target.schema))) -%}
+    {%- endif -%}
 
     {% set src_dbt_exposures = source('dbt_artifacts', 'exposures') %}
     {{ dbt_artifacts.create_exposures_table_if_not_exists(src_dbt_exposures.database, src_dbt_exposures.schema, src_dbt_exposures.identifier) }}


### PR DESCRIPTION
In my warehouse a user that runs dbt does not have privileges to run "CREATE SCHEMA IF NOT EXISTS", hence disabling artifact schema creation as an option sounds like a good idea. By default schema is created, if you supply dbt_artifacts_create_schema: false, the schema will not be created.