### PR TITLE
Escape quotes in name/unique_id for exposures

### DIFF
--- a/integration_test_project/models/tests_and_exposures.yml
+++ b/integration_test_project/models/tests_and_exposures.yml
@@ -10,7 +10,7 @@ models:
           - unique
 
 exposures:
-  - name: imaginary
+  - name: "ceo's imaginary dashboard"
     type: dashboard
     maturity: high
     description: "ceo's favourite dashboard"

--- a/macros/upload_exposures.sql
+++ b/macros/upload_exposures.sql
@@ -24,9 +24,9 @@
         {% for exposure in exposures -%}
             (
                 '{{ invocation_id }}', {# command_invocation_id #}
-                '{{ exposure.unique_id }}', {# node_id #}
+                '{{ exposure.unique_id | replace('\\', '\\\\') }}', {# node_id #}
                 '{{ run_started_at }}', {# run_started_at #}
-                '{{ exposure.name }}', {# name #}
+                '{{ exposure.name | replace('\\', '\\\\') }}', {# name #}
                 '{{ exposure.type }}', {# type #}
                 '{{ tojson(exposure.owner) }}', {# owner #}
                 '{{ exposure.maturity }}', {# maturity #}


### PR DESCRIPTION
Designed to resolve #180.

Note: Untested locally, I'm relying on CI to make sure this works.