### PR TITLE
Safe cast field to INT to avoid failure on casting error

### DIFF
--- a/macros/upload_model_executions.sql
+++ b/macros/upload_model_executions.sql
@@ -187,7 +187,7 @@
                 {% endif %}
 
                 {{ model.execution_time }}, {# total_node_runtime #}
-                '{{ model.adapter_response.rows_affected }}', {# rows_affected #}
+                try_cast('{{ model.adapter_response.rows_affected }}' as int), {# rows_affected #}
                 '{{ model.node.config.materialized }}', {# materialization #}
                 '{{ model.node.schema }}', {# schema #}
                 '{{ model.node.name }}' {# name #}

--- a/macros/upload_seed_executions.sql
+++ b/macros/upload_seed_executions.sql
@@ -186,7 +186,7 @@
                 {% endif %}
 
                 {{ model.execution_time }}, {# total_node_runtime #}
-                '{{ model.adapter_response.rows_affected }}', {# rows_affected #}
+                try_cast('{{ model.adapter_response.rows_affected }}' as int), {# rows_affected #}
                 '{{ model.node.config.materialized }}', {# materialization #}
                 '{{ model.node.schema }}', {# schema #}
                 '{{ model.node.name }}' {# name #}

--- a/macros/upload_snapshot_executions.sql
+++ b/macros/upload_snapshot_executions.sql
@@ -186,7 +186,7 @@
                 {% endif %}
 
                 {{ model.execution_time }}, {# total_node_runtime #}
-                '{{ model.adapter_response.rows_affected }}', {# rows_affected #}
+                try_cast('{{ model.adapter_response.rows_affected }}' as int), {# rows_affected #}
                 '{{ model.node.config.materialized }}', {# materialization #}
                 '{{ model.node.schema }}', {# schema #}
                 '{{ model.node.name }}' {# name #}


### PR DESCRIPTION
Failures in the `run-end-hook` are occurring in snowflake production because the extracted `rows_affected` field from the manifest is a string and occasionally fails insertion into an INT column

Adding safe casting to avoid failure.

In our case, what's causing the failure is a custom materialization type called `insert_by_period` in a [3rd party package](https://github.com/Datavault-UK/dbtvault) that's reporting the rows_affected as an empty string. Bigquery already has the casting implemented so it makes sense to add the same for snowflake!