### PR TITLE
Change parse_json to try_parse_json to avoid upload models errors

### DIFF
--- a/macros/parse_json.sql
+++ b/macros/parse_json.sql
@@ -7,10 +7,9 @@
 {%- endmacro %}
 
 {% macro snowflake__parse_json(field) -%}
-    parse_json({{ field }})
+    try_parse_json({{ field }})
 {%- endmacro %}
 
 {% macro bigquery__parse_json(field) -%}
     parse_json({{ field }})
 {%- endmacro %}
-


### PR DESCRIPTION
We are trying to add `dbt_artifacts` to our monorepo that is has almost 2000 models. Our projects run on Snowflake.
Initial tests of the `upload_results` post hook were failing due to the error `Error parsing JSON: missing comma, pos 184`. After debugging it a bit it appeared that `parse_json` function in "Upload models" step was triggering this error.
![image](https://user-images.githubusercontent.com/63804866/194403583-118b526f-f912-4551-a173-ca26dc0375d0.png)
After changing `parse_json` to `try_parse_json` it seems to work fine. It would be interesting to figure out why `{{ tojson(model.depends_on.nodes) }}` is not doing a great job for some nodes.
It might be the case with other dbs as well. I tested it only for Snowflake.
