### PR TITLE
Add invocation args column to invocation models

### DIFF
--- a/.github/workflows/ci_test_package.yml
+++ b/.github/workflows/ci_test_package.yml
@@ -109,7 +109,7 @@ jobs:
       name: Approve Integration Tests
 
     steps:
-      - name: Checkout branch
+      - name: Checkout Branch
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.sha }} # Check out the code of the PR

--- a/.github/workflows/ci_test_package.yml
+++ b/.github/workflows/ci_test_package.yml
@@ -115,7 +115,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }} # Check out the code of the PR
 
       - name: Install Python packages
-        run: python -m pip install dbt-snowflake~=1.2.0 sqlfluff-templater-dbt
+        run: python -m pip install dbt-snowflake~=1.3.0 sqlfluff-templater-dbt
 
       - name: Test database connection
         run: dbt debug

--- a/.github/workflows/main_test_package.yml
+++ b/.github/workflows/main_test_package.yml
@@ -98,7 +98,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Install Python packages
-        run: python -m pip install dbt-snowflake~=1.2.0 sqlfluff-templater-dbt
+        run: python -m pip install dbt-snowflake~=1.3.0 sqlfluff-templater-dbt
 
       - name: Test database connection
         run: dbt debug

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 name: 'dbt_artifacts'
 version: '2.1.1'
 config-version: 2
-require-dbt-version: ">=1.2.0"
+require-dbt-version: ">=1.3.0"
 profile: "dbt_artifacts"
 
 clean-targets: # folders to be removed by `dbt clean`

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 name: 'dbt_artifacts'
 version: '2.1.1'
 config-version: 2
-require-dbt-version: ">=1.3.0"
+require-dbt-version: ">=1.2.0"
 profile: "dbt_artifacts"
 
 clean-targets: # folders to be removed by `dbt clean`

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 name: 'dbt_artifacts'
 version: '2.1.0'
 config-version: 2
-require-dbt-version: ">=1.2.0"
+require-dbt-version: ">=1.3.0"
 profile: "dbt_artifacts"
 
 clean-targets: # folders to be removed by `dbt clean`

--- a/macros/upload_invocations.sql
+++ b/macros/upload_invocations.sql
@@ -61,9 +61,9 @@
         {% else %}
             null, {# dbt_vars #}
         {% endif %}
-        
+
         '{{ tojson(invocation_args_dict) }}' {# invocation_args #}
-        
+
     )
     {% endset %}
     {{ invocation_values }}
@@ -111,7 +111,7 @@
         {% endif %}
 
         parse_json('{{ tojson(invocation_args_dict) }}') {# invocation_args #}
-        
+
         )
     {% endset %}
     {{ invocation_values }}

--- a/macros/upload_invocations.sql
+++ b/macros/upload_invocations.sql
@@ -62,7 +62,7 @@
             null, {# dbt_vars #}
         {% endif %}
         
-        '{{ tojson(invocation_args) }}' {# invocation_args #}
+        '{{ tojson(invocation_args_dict) }}' {# invocation_args #}
         
     )
     {% endset %}
@@ -110,7 +110,7 @@
             null, {# dbt_vars #}
         {% endif %}
 
-        parse_json('{{ tojson(invocation_args) }}') {# invocation_args #}
+        parse_json('{{ tojson(invocation_args_dict) }}') {# invocation_args #}
         
         )
     {% endset %}

--- a/macros/upload_invocations.sql
+++ b/macros/upload_invocations.sql
@@ -21,7 +21,8 @@
         nullif({{ adapter.dispatch('column_identifier', 'dbt_artifacts')(14) }}, ''),
         nullif({{ adapter.dispatch('column_identifier', 'dbt_artifacts')(15) }}, ''),
         {{ adapter.dispatch('parse_json', 'dbt_artifacts')(adapter.dispatch('column_identifier', 'dbt_artifacts')(16)) }},
-        {{ adapter.dispatch('parse_json', 'dbt_artifacts')(adapter.dispatch('column_identifier', 'dbt_artifacts')(17)) }}
+        {{ adapter.dispatch('parse_json', 'dbt_artifacts')(adapter.dispatch('column_identifier', 'dbt_artifacts')(17)) }},
+        {{ adapter.dispatch('parse_json', 'dbt_artifacts')(adapter.dispatch('column_identifier', 'dbt_artifacts')(18)) }}
     from values
     (
         '{{ invocation_id }}', {# command_invocation_id #}
@@ -56,10 +57,17 @@
             {% for dbt_var in var('dbt_vars') %}
                 {% do dbt_vars_dict.update({dbt_var: var(dbt_var)}) %}
             {% endfor %}
-            '{{ tojson(dbt_vars_dict) }}' {# dbt_vars #}
+            '{{ tojson(dbt_vars_dict) }}', {# dbt_vars #}
         {% else %}
-            null {# dbt_vars #}
+            null, {# dbt_vars #}
         {% endif %}
+        
+        {% set invocation_args = {} %}
+        {% for arg, value in invocation_args_dict.items() %}
+            {% do invocation_args.update({arg: value}) %}
+        {% endfor %}
+        '{{ tojson(invocation_args) }}' {# invocation_args #}
+        
     )
     {% endset %}
     {{ invocation_values }}
@@ -101,10 +109,17 @@
             {% for dbt_var in var('dbt_vars') %}
                 {% do dbt_vars_dict.update({dbt_var: var(dbt_var)}) %}
             {% endfor %}
-            parse_json('{{ tojson(dbt_vars_dict) }}') {# dbt_vars #}
+            parse_json('{{ tojson(dbt_vars_dict) }}'), {# dbt_vars #}
         {% else %}
-            null {# dbt_vars #}
+            null, {# dbt_vars #}
         {% endif %}
+
+        {% set invocation_args = {} %}
+        {% for arg, value in invocation_args_dict.items() %}
+            {% do invocation_args.update({arg: value}) %}
+        {% endfor %}
+        parse_json('{{ tojson(invocation_args) }}') {# invocation_args #}
+        
         )
     {% endset %}
     {{ invocation_values }}

--- a/macros/upload_invocations.sql
+++ b/macros/upload_invocations.sql
@@ -62,10 +62,6 @@
             null, {# dbt_vars #}
         {% endif %}
         
-        {% set invocation_args = {} %}
-        {% for arg, value in invocation_args_dict.items() %}
-            {% do invocation_args.update({arg: value}) %}
-        {% endfor %}
         '{{ tojson(invocation_args) }}' {# invocation_args #}
         
     )
@@ -114,10 +110,6 @@
             null, {# dbt_vars #}
         {% endif %}
 
-        {% set invocation_args = {} %}
-        {% for arg, value in invocation_args_dict.items() %}
-            {% do invocation_args.update({arg: value}) %}
-        {% endfor %}
         parse_json('{{ tojson(invocation_args) }}') {# invocation_args #}
         
         )

--- a/models/docs.md
+++ b/models/docs.md
@@ -376,3 +376,9 @@ Total time spent executing the node's last run (seconds).
 The meta field of the config associated with the node.
 
 {% enddocs %}
+
+{% docs invocation_args %}
+
+Key-value pairs of args passed to invocation.
+
+{% enddocs %}

--- a/models/fct_dbt__invocations.sql
+++ b/models/fct_dbt__invocations.sql
@@ -24,7 +24,8 @@ invocations as (
         dbt_cloud_run_reason_category,
         dbt_cloud_run_reason,
         env_vars,
-        dbt_vars
+        dbt_vars,
+        invocation_args
     from base
 
 )

--- a/models/fct_dbt__invocations.yml
+++ b/models/fct_dbt__invocations.yml
@@ -38,3 +38,5 @@ models:
     description: '{{ doc("env_vars") }}'
   - name: dbt_vars
     description: '{{ doc("dbt_vars") }}'
+  - name: invocation_args
+    description: '{{ doc("invocation_args") }}'

--- a/models/sources/invocations.sql
+++ b/models/sources/invocations.sql
@@ -20,6 +20,7 @@ select
     cast(null as {{ type_string() }}) as dbt_cloud_run_reason_category,
     cast(null as {{ type_string() }}) as dbt_cloud_run_reason,
     cast(null as {{ type_json() }}) as env_vars,
-    cast(null as {{ type_json() }}) as dbt_vars
+    cast(null as {{ type_json() }}) as dbt_vars,
+    cast(null as {{ type_json() }}) as invocation_args
 from dummy_cte
 where 1 = 0

--- a/models/staging/stg_dbt__invocations.sql
+++ b/models/staging/stg_dbt__invocations.sql
@@ -25,7 +25,7 @@ enhanced as (
         dbt_cloud_run_reason,
         env_vars,
         dbt_vars,
-        invocation_args    
+        invocation_args
     from base
 
 )

--- a/models/staging/stg_dbt__invocations.sql
+++ b/models/staging/stg_dbt__invocations.sql
@@ -24,7 +24,8 @@ enhanced as (
         dbt_cloud_run_reason_category,
         dbt_cloud_run_reason,
         env_vars,
-        dbt_vars
+        dbt_vars,
+        invocation_args    
     from base
 
 )

--- a/models/staging/stg_dbt__invocations.yml
+++ b/models/staging/stg_dbt__invocations.yml
@@ -38,3 +38,5 @@ models:
     description: '{{ doc("env_vars") }}'
   - name: dbt_vars
     description: '{{ doc("dbt_vars") }}'
+  - name: invocation_args
+    description: '{{ doc("invocation_args") }}'

--- a/tox.ini
+++ b/tox.ini
@@ -124,7 +124,7 @@ commands =
 
 [testenv:integration_databricks]
 changedir = integration_test_project
-deps = dbt-databricks~=1.3.0
+deps = dbt-databricks~=1.2.3
 commands =
     dbt deps
     dbt build --target databricks

--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ rules = L001,L003,L004,L005,L006,L007,L008,L010,L011,L012,L014,L015,L017,L018,L0
 
 deps =
     sqlfluff-templater-dbt
-    dbt-snowflake~=1.2.0
+    dbt-snowflake~=1.3.0
 
 [sqlfluff:rules:L004]
 indent_unit = space
@@ -112,33 +112,33 @@ deps = {[sqlfluff]deps}
 commands = sqlfluff fix models --ignore parsing
 
 [testenv:generate_docs]
-deps = dbt-snowflake~=1.2.0
+deps = dbt-snowflake~=1.3.0
 commands = dbt docs generate --profiles-dir integration_test_project
 
 [testenv:integration_snowflake]
 changedir = integration_test_project
-deps = dbt-snowflake~=1.2.0
+deps = dbt-snowflake~=1.3.0
 commands =
     dbt deps
     dbt build --target snowflake
 
 [testenv:integration_databricks]
 changedir = integration_test_project
-deps = dbt-databricks~=1.2.0
+deps = dbt-databricks~=1.3.0
 commands =
     dbt deps
     dbt build --target databricks
 
 [testenv:integration_bigquery]
 changedir = integration_test_project
-deps = dbt-bigquery~=1.2.0
+deps = dbt-bigquery~=1.3.0
 commands =
     dbt deps
     dbt build --target bigquery
 
 [testenv:integration_spark]
 changedir = integration_test_project
-deps = dbt-spark[ODBC]~=1.2.0
+deps = dbt-spark[ODBC]~=1.3.0
 commands =
     dbt deps
     dbt build --target spark

--- a/tox.ini
+++ b/tox.ini
@@ -124,7 +124,7 @@ commands =
 
 [testenv:integration_databricks]
 changedir = integration_test_project
-deps = dbt-databricks~=1.2.3
+deps = dbt-databricks~=1.3.0
 commands =
     dbt deps
     dbt build --target databricks


### PR DESCRIPTION
Partially Resolves #135 

- Adds new column to invocation models using {{ invocation_args_dict }} as [implemented in dbt core here](https://github.com/dbt-labs/dbt-core/pull/5782)
- Partially resolves the issue as the new column contains all the arguments passed to a dbt invocation but the command is split between different keys within the JSON object. Therefore we won't see **dbt run --select this model --exclude this-other-model** as a value within in a single key.