### PR TITLE
Add backticks to BigQuery table IDs for insertion as otherwise it throws an error for table id with '-'

### DIFF
--- a/macros/insert_into_metadata_table.sql
+++ b/macros/insert_into_metadata_table.sql
@@ -25,7 +25,7 @@
 {% macro bigquery__insert_into_metadata_table(database_name, schema_name, table_name, content) -%}
 
         {% set insert_into_table_query %}
-        insert into {{database_name}}.{{ schema_name }}.{{ table_name }}
+        insert into `{{database_name}}.{{ schema_name }}.{{ table_name }}`
         VALUES
         {{ content }}
         {% endset %}


### PR DESCRIPTION
…ws an error in case table name has a '-'