### PR TITLE
Add alias column to artifact uploads

### DIFF
--- a/integration_test_project/models/aliased.sql
+++ b/integration_test_project/models/aliased.sql
@@ -1,0 +1,9 @@
+{{
+    config(
+        alias = 'my_alias',
+    )
+}}
+
+select
+    1 as id,
+    'banana' as fruit

--- a/macros/upload_model_executions.sql
+++ b/macros/upload_model_executions.sql
@@ -24,7 +24,8 @@
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(10) }},
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(11) }},
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(12) }},
-            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(13) }}
+            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(13) }},
+            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(14) }}
         from values
         {% for model in models -%}
             (
@@ -66,7 +67,8 @@
                 null, -- rows_affected not available {# Only available in Snowflake & BigQuery #}
                 '{{ model.node.config.materialized }}', {# materialization #}
                 '{{ model.node.schema }}', {# schema #}
-                '{{ model.node.name }}' {# name #}
+                '{{ model.node.name }}', {# name #}
+                '{{ model.node.alias }}' {# alias #}
             )
             {%- if not loop.last %},{%- endif %}
         {%- endfor %}
@@ -121,7 +123,8 @@
             safe_cast('{{ model.adapter_response.bytes_processed }}' as int64),
             '{{ model.node.config.materialized }}', {# materialization #}
             '{{ model.node.schema }}', {# schema #}
-            '{{ model.node.name }}' {# name #}
+            '{{ model.node.name }}', {# name #}
+            '{{ model.node.alias }}' {# alias #}
             )
             {%- if not loop.last %},{%- endif %}
         {%- endfor %}
@@ -148,7 +151,8 @@
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(10) }},
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(11) }},
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(12) }},
-            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(13) }}
+            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(13) }},
+            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(14) }}
         from values
         {% for model in models -%}
             (
@@ -190,7 +194,8 @@
                 try_cast('{{ model.adapter_response.rows_affected }}' as int), {# rows_affected #}
                 '{{ model.node.config.materialized }}', {# materialization #}
                 '{{ model.node.schema }}', {# schema #}
-                '{{ model.node.name }}' {# name #}
+                '{{ model.node.name }}', {# name #}
+                '{{ model.node.alias }}' {# alias #}
             )
             {%- if not loop.last %},{%- endif %}
         {%- endfor %}

--- a/macros/upload_models.sql
+++ b/macros/upload_models.sql
@@ -17,14 +17,14 @@
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(4) }},
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(5) }},
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(6) }},
-            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(7) }},
-            {{ adapter.dispatch('parse_json', 'dbt_artifacts')(adapter.dispatch('column_identifier', 'dbt_artifacts')(8)) }},
+            {{ adapter.dispatch('parse_json', 'dbt_artifacts')(adapter.dispatch('column_identifier', 'dbt_artifacts')(7)) }},
+            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(8) }},
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(9) }},
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(10) }},
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(11) }},
-            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(12) }},
+            {{ adapter.dispatch('parse_json', 'dbt_artifacts')(adapter.dispatch('column_identifier', 'dbt_artifacts')(12)) }},
             {{ adapter.dispatch('parse_json', 'dbt_artifacts')(adapter.dispatch('column_identifier', 'dbt_artifacts')(13)) }},
-            {{ adapter.dispatch('parse_json', 'dbt_artifacts')(adapter.dispatch('column_identifier', 'dbt_artifacts')(14)) }}
+            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(14) }}
         from values
         {% for model in models -%}
             (
@@ -34,14 +34,14 @@
                 '{{ model.database }}', {# database #}
                 '{{ model.schema }}', {# schema #}
                 '{{ model.name }}', {# name #}
-                '{{ model.alias }}', {# alias #}
                 '{{ tojson(model.depends_on.nodes) | replace('\\', '\\\\') }}', {# depends_on_nodes #}
                 '{{ model.package_name }}', {# package_name #}
                 '{{ model.original_file_path | replace('\\', '\\\\') }}', {# path #}
                 '{{ model.checksum.checksum }}', {# checksum #}
                 '{{ model.config.materialized }}', {# materialization #}
                 '{{ tojson(model.tags) }}', {# tags #}
-                '{{ tojson(model.config.meta) }}' {# meta #}
+                '{{ tojson(model.config.meta) }}', {# meta #}
+                '{{ model.alias }}' {# alias #}
             )
             {%- if not loop.last %},{%- endif %}
         {%- endfor %}
@@ -63,14 +63,14 @@
                     '{{ model.database }}', {# database #}
                     '{{ model.schema }}', {# schema #}
                     '{{ model.name }}', {# name #}
-                    '{{ model.alias }}', {# alias #}
                     {{ tojson(model.depends_on.nodes) }}, {# depends_on_nodes #}
                     '{{ model.package_name }}', {# package_name #}
                     '{{ model.original_file_path | replace('\\', '\\\\') }}', {# path #}
                     '{{ model.checksum.checksum }}', {# checksum #}
                     '{{ model.config.materialized }}', {# materialization #}
                     {{ tojson(model.tags) }}, {# tags #}
-                    parse_json('{{ tojson(model.config.meta) }}') {# meta #}
+                    parse_json('{{ tojson(model.config.meta) }}'), {# meta #}
+                    '{{ model.alias }}' {# alias #}
                 )
                 {%- if not loop.last %},{%- endif %}
             {%- endfor %}

--- a/macros/upload_models.sql
+++ b/macros/upload_models.sql
@@ -17,13 +17,14 @@
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(4) }},
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(5) }},
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(6) }},
-            {{ adapter.dispatch('parse_json', 'dbt_artifacts')(adapter.dispatch('column_identifier', 'dbt_artifacts')(7)) }},
-            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(8) }},
+            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(7) }},
+            {{ adapter.dispatch('parse_json', 'dbt_artifacts')(adapter.dispatch('column_identifier', 'dbt_artifacts')(8)) }},
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(9) }},
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(10) }},
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(11) }},
-            {{ adapter.dispatch('parse_json', 'dbt_artifacts')(adapter.dispatch('column_identifier', 'dbt_artifacts')(12)) }},
-            {{ adapter.dispatch('parse_json', 'dbt_artifacts')(adapter.dispatch('column_identifier', 'dbt_artifacts')(13)) }}
+            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(12) }},
+            {{ adapter.dispatch('parse_json', 'dbt_artifacts')(adapter.dispatch('column_identifier', 'dbt_artifacts')(13)) }},
+            {{ adapter.dispatch('parse_json', 'dbt_artifacts')(adapter.dispatch('column_identifier', 'dbt_artifacts')(14)) }}
         from values
         {% for model in models -%}
             (
@@ -33,6 +34,7 @@
                 '{{ model.database }}', {# database #}
                 '{{ model.schema }}', {# schema #}
                 '{{ model.name }}', {# name #}
+                '{{ model.alias }}', {# alias #}
                 '{{ tojson(model.depends_on.nodes) | replace('\\', '\\\\') }}', {# depends_on_nodes #}
                 '{{ model.package_name }}', {# package_name #}
                 '{{ model.original_file_path | replace('\\', '\\\\') }}', {# path #}
@@ -61,6 +63,7 @@
                     '{{ model.database }}', {# database #}
                     '{{ model.schema }}', {# schema #}
                     '{{ model.name }}', {# name #}
+                    '{{ model.alias }}', {# alias #}
                     {{ tojson(model.depends_on.nodes) }}, {# depends_on_nodes #}
                     '{{ model.package_name }}', {# package_name #}
                     '{{ model.original_file_path | replace('\\', '\\\\') }}', {# path #}

--- a/macros/upload_seed_executions.sql
+++ b/macros/upload_seed_executions.sql
@@ -24,7 +24,8 @@
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(10) }},
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(11) }},
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(12) }},
-            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(13) }}
+            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(13) }},
+            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(14) }}
         from values
         {% for model in seeds -%}
             (
@@ -66,7 +67,8 @@
                 null, -- rows_affected not available {# Only available in Snowflake #}
                 '{{ model.node.config.materialized }}', {# materialization #}
                 '{{ model.node.schema }}', {# schema #}
-                '{{ model.node.name }}' {# name #}
+                '{{ model.node.name }}', {# name #}
+                '{{ model.node.alias }}' {# alias #}
             )
             {%- if not loop.last %},{%- endif %}
         {%- endfor %}
@@ -120,7 +122,8 @@
                 null, -- rows_affected not available {# Databricks #}
                 '{{ model.node.config.materialized }}', {# materialization #}
                 '{{ model.node.schema }}', {# schema #}
-                '{{ model.node.name }}' {# name #}
+                '{{ model.node.name }}', {# name #}
+                '{{ model.node.alias }}' {# alias #}
             )
             {%- if not loop.last %},{%- endif %}
         {%- endfor %}
@@ -147,7 +150,8 @@
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(10) }},
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(11) }},
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(12) }},
-            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(13) }}
+            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(13) }},
+            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(14) }}
         from values
         {% for model in seeds -%}
             (
@@ -189,7 +193,8 @@
                 try_cast('{{ model.adapter_response.rows_affected }}' as int), {# rows_affected #}
                 '{{ model.node.config.materialized }}', {# materialization #}
                 '{{ model.node.schema }}', {# schema #}
-                '{{ model.node.name }}' {# name #}
+                '{{ model.node.name }}', {# name #}
+                '{{ model.node.alias }}' {# alias #}
             )
             {%- if not loop.last %},{%- endif %}
         {%- endfor %}

--- a/macros/upload_seeds.sql
+++ b/macros/upload_seeds.sql
@@ -20,8 +20,8 @@
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(7) }},
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(8) }},
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(9) }},
-            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(10) }},
-            {{ adapter.dispatch('parse_json', 'dbt_artifacts')(adapter.dispatch('column_identifier', 'dbt_artifacts')(11)) }}
+            {{ adapter.dispatch('parse_json', 'dbt_artifacts')(adapter.dispatch('column_identifier', 'dbt_artifacts')(10)) }},
+            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(11) }}
         from values
         {% for seed in seeds -%}
             (
@@ -31,11 +31,11 @@
                 '{{ seed.database }}', {# database #}
                 '{{ seed.schema }}', {# schema #}
                 '{{ seed.name }}', {# name #}
-                '{{ seed.alias }}', {# alias #}
                 '{{ seed.package_name }}', {# package_name #}
                 '{{ seed.original_file_path | replace('\\', '\\\\') }}', {# path #}
                 '{{ seed.checksum.checksum }}', {# checksum #}
-                '{{ tojson(seed.config.meta) }}' {# meta #}
+                '{{ tojson(seed.config.meta) }}', {# meta #}
+                '{{ seed.alias }}' {# alias #}
             )
             {%- if not loop.last %},{%- endif %}
         {%- endfor %}
@@ -57,11 +57,11 @@
                     '{{ seed.database }}', {# database #}
                     '{{ seed.schema }}', {# schema #}
                     '{{ seed.name }}', {# name #}
-                    '{{ seed.alias }}', {# alias #}
                     '{{ seed.package_name }}', {# package_name #}
                     '{{ seed.original_file_path | replace('\\', '\\\\') }}', {# path #}
                     '{{ seed.checksum.checksum }}', {# checksum #}
-                    parse_json('{{ tojson(seed.config.meta) }}') {# meta #}
+                    parse_json('{{ tojson(seed.config.meta) }}'), {# meta #}
+                    '{{ seed.alias }}' {# alias #}
                 )
                 {%- if not loop.last %},{%- endif %}
             {%- endfor %}

--- a/macros/upload_seeds.sql
+++ b/macros/upload_seeds.sql
@@ -20,7 +20,8 @@
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(7) }},
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(8) }},
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(9) }},
-            {{ adapter.dispatch('parse_json', 'dbt_artifacts')(adapter.dispatch('column_identifier', 'dbt_artifacts')(10)) }}
+            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(10) }},
+            {{ adapter.dispatch('parse_json', 'dbt_artifacts')(adapter.dispatch('column_identifier', 'dbt_artifacts')(11)) }}
         from values
         {% for seed in seeds -%}
             (
@@ -30,6 +31,7 @@
                 '{{ seed.database }}', {# database #}
                 '{{ seed.schema }}', {# schema #}
                 '{{ seed.name }}', {# name #}
+                '{{ seed.alias }}', {# alias #}
                 '{{ seed.package_name }}', {# package_name #}
                 '{{ seed.original_file_path | replace('\\', '\\\\') }}', {# path #}
                 '{{ seed.checksum.checksum }}', {# checksum #}
@@ -55,6 +57,7 @@
                     '{{ seed.database }}', {# database #}
                     '{{ seed.schema }}', {# schema #}
                     '{{ seed.name }}', {# name #}
+                    '{{ seed.alias }}', {# alias #}
                     '{{ seed.package_name }}', {# package_name #}
                     '{{ seed.original_file_path | replace('\\', '\\\\') }}', {# path #}
                     '{{ seed.checksum.checksum }}', {# checksum #}

--- a/macros/upload_snapshot_executions.sql
+++ b/macros/upload_snapshot_executions.sql
@@ -24,6 +24,7 @@
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(10) }},
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(11) }},
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(12) }},
+            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(13) }},
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(13) }}
         from values
         {% for model in snapshots -%}
@@ -66,7 +67,8 @@
                 null, -- rows_affected not available {# Only available in Snowflake #}
                 '{{ model.node.config.materialized }}', {# materialization #}
                 '{{ model.node.schema }}', {# schema #}
-                '{{ model.node.name }}' {# name #}
+                '{{ model.node.name }}', {# name #}
+                '{{ model.node.alias }}' {# alias #}
             )
             {%- if not loop.last %},{%- endif %}
         {%- endfor %}
@@ -120,7 +122,8 @@
                 null, -- rows_affected not available {# Databricks #}
                 '{{ model.node.config.materialized }}', {# materialization #}
                 '{{ model.node.schema }}', {# schema #}
-                '{{ model.node.name }}' {# name #}
+                '{{ model.node.name }}', {# name #}
+                '{{ model.node.alias }}' {# alias #}
             )
             {%- if not loop.last %},{%- endif %}
         {%- endfor %}
@@ -147,7 +150,8 @@
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(10) }},
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(11) }},
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(12) }},
-            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(13) }}
+            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(13) }},
+            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(14) }}
         from values
         {% for model in snapshots -%}
             (
@@ -189,7 +193,8 @@
                 try_cast('{{ model.adapter_response.rows_affected }}' as int), {# rows_affected #}
                 '{{ model.node.config.materialized }}', {# materialization #}
                 '{{ model.node.schema }}', {# schema #}
-                '{{ model.node.name }}' {# name #}
+                '{{ model.node.name }}', {# name #}
+                '{{ model.node.alias }}' {# alias #}
             )
             {%- if not loop.last %},{%- endif %}
         {%- endfor %}

--- a/macros/upload_snapshots.sql
+++ b/macros/upload_snapshots.sql
@@ -18,13 +18,13 @@
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(4) }},
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(5) }},
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(6) }},
-            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(7) }},
-            {{ adapter.dispatch('parse_json', 'dbt_artifacts')(adapter.dispatch('column_identifier', 'dbt_artifacts')(8)) }},
+            {{ adapter.dispatch('parse_json', 'dbt_artifacts')(adapter.dispatch('column_identifier', 'dbt_artifacts')(7)) }},
+            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(8) }},
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(9) }},
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(10) }},
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(11) }},
-            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(12) }},
-            {{ adapter.dispatch('parse_json', 'dbt_artifacts')(adapter.dispatch('column_identifier', 'dbt_artifacts')(13)) }}
+            {{ adapter.dispatch('parse_json', 'dbt_artifacts')(adapter.dispatch('column_identifier', 'dbt_artifacts')(12)) }},
+            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(13) }}
         from values
         {% for snapshot in snapshots -%}
             (
@@ -34,13 +34,13 @@
                 '{{ snapshot.database }}', {# database #}
                 '{{ snapshot.schema }}', {# schema #}
                 '{{ snapshot.name }}', {# name #}
-                '{{ snapshot.alias }}', {# alias #}
                 '{{ tojson(snapshot.depends_on.nodes) }}', {# depends_on_nodes #}
                 '{{ snapshot.package_name }}', {# package_name #}
                 '{{ snapshot.original_file_path | replace('\\', '\\\\') }}', {# path #}
                 '{{ snapshot.checksum.checksum }}', {# checksum #}
                 '{{ snapshot.config.strategy }}', {# strategy #}
-                '{{ tojson(snapshot.config.meta) }}' {# meta #}
+                '{{ tojson(snapshot.config.meta) }}', {# meta #}
+                '{{ snapshot.alias }}' {# alias #}
             )
             {%- if not loop.last %},{%- endif %}
         {%- endfor %}
@@ -62,13 +62,13 @@
                     '{{ snapshot.database }}', {# database #}
                     '{{ snapshot.schema }}', {# schema #}
                     '{{ snapshot.name }}', {# name #}
-                    '{{ snapshot.alias }}', {# alias #}
                     {{ tojson(snapshot.depends_on.nodes) }}, {# depends_on_nodes #}
                     '{{ snapshot.package_name }}', {# package_name #}
                     '{{ snapshot.original_file_path | replace('\\', '\\\\') }}', {# path #}
                     '{{ snapshot.checksum.checksum }}', {# checksum #}
                     '{{ snapshot.config.strategy }}', {# strategy #}
-                    parse_json('{{ tojson(snapshot.config.meta) }}') {# meta #}
+                    parse_json('{{ tojson(snapshot.config.meta) }}'), {# meta #}
+                    '{{ snapshot.alias }}' {# alias #}
                 )
                 {%- if not loop.last %},{%- endif %}
             {%- endfor %}

--- a/macros/upload_snapshots.sql
+++ b/macros/upload_snapshots.sql
@@ -18,12 +18,13 @@
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(4) }},
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(5) }},
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(6) }},
-            {{ adapter.dispatch('parse_json', 'dbt_artifacts')(adapter.dispatch('column_identifier', 'dbt_artifacts')(7)) }},
-            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(8) }},
+            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(7) }},
+            {{ adapter.dispatch('parse_json', 'dbt_artifacts')(adapter.dispatch('column_identifier', 'dbt_artifacts')(8)) }},
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(9) }},
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(10) }},
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(11) }},
-            {{ adapter.dispatch('parse_json', 'dbt_artifacts')(adapter.dispatch('column_identifier', 'dbt_artifacts')(12)) }}
+            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(12) }},
+            {{ adapter.dispatch('parse_json', 'dbt_artifacts')(adapter.dispatch('column_identifier', 'dbt_artifacts')(13)) }}
         from values
         {% for snapshot in snapshots -%}
             (
@@ -33,6 +34,7 @@
                 '{{ snapshot.database }}', {# database #}
                 '{{ snapshot.schema }}', {# schema #}
                 '{{ snapshot.name }}', {# name #}
+                '{{ snapshot.alias }}', {# alias #}
                 '{{ tojson(snapshot.depends_on.nodes) }}', {# depends_on_nodes #}
                 '{{ snapshot.package_name }}', {# package_name #}
                 '{{ snapshot.original_file_path | replace('\\', '\\\\') }}', {# path #}
@@ -60,6 +62,7 @@
                     '{{ snapshot.database }}', {# database #}
                     '{{ snapshot.schema }}', {# schema #}
                     '{{ snapshot.name }}', {# name #}
+                    '{{ snapshot.alias }}', {# alias #}
                     {{ tojson(snapshot.depends_on.nodes) }}, {# depends_on_nodes #}
                     '{{ snapshot.package_name }}', {# package_name #}
                     '{{ snapshot.original_file_path | replace('\\', '\\\\') }}', {# path #}

--- a/models/dim_dbt__models.sql
+++ b/models/dim_dbt__models.sql
@@ -15,14 +15,14 @@ models as (
         database,
         schema,
         name,
-        alias,
         depends_on_nodes,
         package_name,
         path,
         checksum,
         materialization,
         tags,
-        meta
+        meta,
+        alias
     from base
 
 )

--- a/models/dim_dbt__models.sql
+++ b/models/dim_dbt__models.sql
@@ -15,6 +15,7 @@ models as (
         database,
         schema,
         name,
+        alias,
         depends_on_nodes,
         package_name,
         path,

--- a/models/dim_dbt__models.yml
+++ b/models/dim_dbt__models.yml
@@ -18,6 +18,8 @@ models:
     description: '{{ doc("model_execution_id") }}'
   - name: name
     description: '{{ doc("name") }}'
+  - name: alias
+    description: '{{ doc("alias") }}'
   - name: node_id
     description: '{{ doc("node_id") }}'
   - name: package_name

--- a/models/dim_dbt__models.yml
+++ b/models/dim_dbt__models.yml
@@ -18,8 +18,6 @@ models:
     description: '{{ doc("model_execution_id") }}'
   - name: name
     description: '{{ doc("name") }}'
-  - name: alias
-    description: '{{ doc("alias") }}'
   - name: node_id
     description: '{{ doc("node_id") }}'
   - name: package_name
@@ -34,3 +32,5 @@ models:
     description: '{{ doc("tags") }}'
   - name: meta
     description: '{{ doc("meta") }}'
+  - name: alias
+    description: '{{ doc("alias") }}'

--- a/models/dim_dbt__seeds.sql
+++ b/models/dim_dbt__seeds.sql
@@ -15,11 +15,11 @@ seeds as (
         database,
         schema,
         name,
-        alias,
         package_name,
         path,
         checksum,
-        meta
+        meta,
+        alias
     from base
 
 )

--- a/models/dim_dbt__seeds.sql
+++ b/models/dim_dbt__seeds.sql
@@ -15,6 +15,7 @@ seeds as (
         database,
         schema,
         name,
+        alias,
         package_name,
         path,
         checksum,

--- a/models/dim_dbt__seeds.yml
+++ b/models/dim_dbt__seeds.yml
@@ -12,6 +12,8 @@ models:
     description: '{{ doc("database") }}'
   - name: name
     description: '{{ doc("name") }}'
+  - name: alias
+    description: '{{ doc("alias") }}'
   - name: node_id
     description: '{{ doc("node_id") }}'
   - name: package_name

--- a/models/dim_dbt__seeds.yml
+++ b/models/dim_dbt__seeds.yml
@@ -12,8 +12,6 @@ models:
     description: '{{ doc("database") }}'
   - name: name
     description: '{{ doc("name") }}'
-  - name: alias
-    description: '{{ doc("alias") }}'
   - name: node_id
     description: '{{ doc("node_id") }}'
   - name: package_name
@@ -26,3 +24,5 @@ models:
     description: '{{ doc("schema") }}'
   - name: seed_execution_id
     description: '{{ doc("seed_execution_id") }}'
+  - name: alias
+    description: '{{ doc("alias") }}'

--- a/models/dim_dbt__snapshots.sql
+++ b/models/dim_dbt__snapshots.sql
@@ -15,13 +15,13 @@ snapshots as (
         database,
         schema,
         name,
-        alias,
         depends_on_nodes,
         package_name,
         path,
         checksum,
         strategy,
-        meta
+        meta,
+        alias
     from base
 
 )

--- a/models/dim_dbt__snapshots.sql
+++ b/models/dim_dbt__snapshots.sql
@@ -15,6 +15,7 @@ snapshots as (
         database,
         schema,
         name,
+        alias,
         depends_on_nodes,
         package_name,
         path,

--- a/models/dim_dbt__snapshots.yml
+++ b/models/dim_dbt__snapshots.yml
@@ -14,6 +14,8 @@ models:
     description: '{{ doc("depends_on_nodes") }}'
   - name: name
     description: '{{ doc("name") }}'
+  - name: alias
+    description: '{{ doc("alias") }}'
   - name: node_id
     description: '{{ doc("node_id") }}'
   - name: package_name

--- a/models/dim_dbt__snapshots.yml
+++ b/models/dim_dbt__snapshots.yml
@@ -14,8 +14,6 @@ models:
     description: '{{ doc("depends_on_nodes") }}'
   - name: name
     description: '{{ doc("name") }}'
-  - name: alias
-    description: '{{ doc("alias") }}'
   - name: node_id
     description: '{{ doc("node_id") }}'
   - name: package_name
@@ -30,3 +28,5 @@ models:
     description: '{{ doc("snapshot_execution_id") }}'
   - name: strategy
     description: '{{ doc("strategy") }}'
+  - name: alias
+    description: '{{ doc("alias") }}'

--- a/models/docs.md
+++ b/models/docs.md
@@ -16,6 +16,12 @@ Name of the node.
 
 {% enddocs %}
 
+{% docs alias %}
+
+Alias of the node.
+
+{% enddocs %}
+
 {% docs schema %}
 
 Configured schema for the node.
@@ -388,5 +394,3 @@ Key-value pairs of args passed to invocation.
 Key-value pairs of environment variables passed to invocation that have the prefix DBT_ENV_CUSTOM_ENV_
 
 {% enddocs %}
-
-

--- a/models/docs.md
+++ b/models/docs.md
@@ -16,12 +16,6 @@ Name of the node.
 
 {% enddocs %}
 
-{% docs alias %}
-
-Alias of the node.
-
-{% enddocs %}
-
 {% docs schema %}
 
 Configured schema for the node.
@@ -392,5 +386,11 @@ Key-value pairs of args passed to invocation.
 {% docs dbt_custom_envs %}
 
 Key-value pairs of environment variables passed to invocation that have the prefix DBT_ENV_CUSTOM_ENV_
+
+{% enddocs %}
+
+{% docs alias %}
+
+Alias of the node.
 
 {% enddocs %}

--- a/models/fct_dbt__model_executions.sql
+++ b/models/fct_dbt__model_executions.sql
@@ -24,7 +24,8 @@ model_executions as (
         {% endif %}
         materialization,
         schema, -- noqa
-        name
+        name,
+        alias
     from base
 
 )

--- a/models/fct_dbt__model_executions.yml
+++ b/models/fct_dbt__model_executions.yml
@@ -14,8 +14,6 @@ models:
     description: '{{ doc("model_execution_id") }}'
   - name: name
     description: '{{ doc("name") }}'
-  - name: alias
-    description: '{{ doc("alias") }}'
   - name: node_id
     description: '{{ doc("node_id") }}'
   - name: query_completed_at
@@ -34,3 +32,5 @@ models:
     description: '{{ doc("total_node_runtime") }}'
   - name: was_full_refresh
     description: '{{ doc("was_full_refresh") }}'
+  - name: alias
+    description: '{{ doc("alias") }}'

--- a/models/fct_dbt__model_executions.yml
+++ b/models/fct_dbt__model_executions.yml
@@ -14,6 +14,8 @@ models:
     description: '{{ doc("model_execution_id") }}'
   - name: name
     description: '{{ doc("name") }}'
+  - name: alias
+    description: '{{ doc("alias") }}'
   - name: node_id
     description: '{{ doc("node_id") }}'
   - name: query_completed_at

--- a/models/fct_dbt__seed_executions.sql
+++ b/models/fct_dbt__seed_executions.sql
@@ -21,7 +21,8 @@ seed_executions as (
         rows_affected,
         materialization,
         schema,
-        name
+        name,
+        alias
     from base
 
 )

--- a/models/fct_dbt__seed_executions.yml
+++ b/models/fct_dbt__seed_executions.yml
@@ -12,8 +12,6 @@ models:
     description: '{{ doc("materialization") }}'
   - name: name
     description: '{{ doc("name") }}'
-  - name: alias
-    description: '{{ doc("alias") }}'
   - name: node_id
     description: '{{ doc("node_id") }}'
   - name: query_completed_at
@@ -32,3 +30,5 @@ models:
     description: '{{ doc("total_node_runtime") }}'
   - name: was_full_refresh
     description: '{{ doc("was_full_refresh") }}'
+  - name: alias
+    description: '{{ doc("alias") }}'

--- a/models/fct_dbt__seed_executions.yml
+++ b/models/fct_dbt__seed_executions.yml
@@ -12,6 +12,8 @@ models:
     description: '{{ doc("materialization") }}'
   - name: name
     description: '{{ doc("name") }}'
+  - name: alias
+    description: '{{ doc("alias") }}'
   - name: node_id
     description: '{{ doc("node_id") }}'
   - name: query_completed_at

--- a/models/fct_dbt__snapshot_executions.sql
+++ b/models/fct_dbt__snapshot_executions.sql
@@ -21,7 +21,8 @@ snapshot_executions as (
         rows_affected,
         materialization,
         schema,
-        name
+        name,
+        alias
     from base
 
 )

--- a/models/fct_dbt__snapshot_executions.yml
+++ b/models/fct_dbt__snapshot_executions.yml
@@ -12,8 +12,6 @@ models:
     description: '{{ doc("materialization") }}'
   - name: name
     description: '{{ doc("name") }}'
-  - name: alias
-    description: '{{ doc("alias") }}'
   - name: node_id
     description: '{{ doc("node_id") }}'
   - name: query_completed_at
@@ -32,3 +30,5 @@ models:
     description: '{{ doc("total_node_runtime") }}'
   - name: was_full_refresh
     description: '{{ doc("was_full_refresh") }}'
+  - name: alias
+    description: '{{ doc("alias") }}'

--- a/models/fct_dbt__snapshot_executions.yml
+++ b/models/fct_dbt__snapshot_executions.yml
@@ -12,6 +12,8 @@ models:
     description: '{{ doc("materialization") }}'
   - name: name
     description: '{{ doc("name") }}'
+  - name: alias
+    description: '{{ doc("alias") }}'
   - name: node_id
     description: '{{ doc("node_id") }}'
   - name: query_completed_at

--- a/models/sources/model_executions.sql
+++ b/models/sources/model_executions.sql
@@ -19,6 +19,7 @@ select
     {% endif %}
     cast(null as {{ type_string() }}) as materialization,
     cast(null as {{ type_string() }}) as schema,
-    cast(null as {{ type_string() }}) as name
+    cast(null as {{ type_string() }}) as name,
+    cast(null as {{ type_string() }}) as alias
 from dummy_cte
 where 1 = 0

--- a/models/sources/models.sql
+++ b/models/sources/models.sql
@@ -10,6 +10,7 @@ select
     cast(null as {{ type_string() }}) as database,
     cast(null as {{ type_string() }}) as schema,
     cast(null as {{ type_string() }}) as name,
+    cast(null as {{ type_string() }}) as alias,
     cast(null as {{ type_array() }}) as depends_on_nodes,
     cast(null as {{ type_string() }}) as package_name,
     cast(null as {{ type_string() }}) as path,

--- a/models/sources/models.sql
+++ b/models/sources/models.sql
@@ -10,13 +10,13 @@ select
     cast(null as {{ type_string() }}) as database,
     cast(null as {{ type_string() }}) as schema,
     cast(null as {{ type_string() }}) as name,
-    cast(null as {{ type_string() }}) as alias,
     cast(null as {{ type_array() }}) as depends_on_nodes,
     cast(null as {{ type_string() }}) as package_name,
     cast(null as {{ type_string() }}) as path,
     cast(null as {{ type_string() }}) as checksum,
     cast(null as {{ type_string() }}) as materialization,
     cast(null as {{ type_array() }}) as tags,
-    cast(null as {{ type_json() }}) as meta
+    cast(null as {{ type_json() }}) as meta,
+    cast(null as {{ type_string() }}) as alias
 from dummy_cte
 where 1 = 0

--- a/models/sources/seed_executions.sql
+++ b/models/sources/seed_executions.sql
@@ -16,6 +16,7 @@ select
     cast(null as {{ type_int() }}) as rows_affected,
     cast(null as {{ type_string() }}) as materialization,
     cast(null as {{ type_string() }}) as schema,
-    cast(null as {{ type_string() }}) as name
+    cast(null as {{ type_string() }}) as name,
+    cast(null as {{ type_string() }}) as alias
 from dummy_cte
 where 1 = 0

--- a/models/sources/seeds.sql
+++ b/models/sources/seeds.sql
@@ -10,6 +10,7 @@ select
     cast(null as {{ type_string() }}) as database,
     cast(null as {{ type_string() }}) as schema,
     cast(null as {{ type_string() }}) as name,
+    cast(null as {{ type_string() }}) as alias,
     cast(null as {{ type_string() }}) as package_name,
     cast(null as {{ type_string() }}) as path,
     cast(null as {{ type_string() }}) as checksum,

--- a/models/sources/seeds.sql
+++ b/models/sources/seeds.sql
@@ -10,10 +10,10 @@ select
     cast(null as {{ type_string() }}) as database,
     cast(null as {{ type_string() }}) as schema,
     cast(null as {{ type_string() }}) as name,
-    cast(null as {{ type_string() }}) as alias,
     cast(null as {{ type_string() }}) as package_name,
     cast(null as {{ type_string() }}) as path,
     cast(null as {{ type_string() }}) as checksum,
-    cast(null as {{ type_json() }}) as meta
+    cast(null as {{ type_json() }}) as meta,
+    cast(null as {{ type_string() }}) as alias
 from dummy_cte
 where 1 = 0

--- a/models/sources/snapshot_executions.sql
+++ b/models/sources/snapshot_executions.sql
@@ -16,6 +16,7 @@ select
     cast(null as {{ type_int() }}) as rows_affected,
     cast(null as {{ type_string() }}) as materialization,
     cast(null as {{ type_string() }}) as schema,
-    cast(null as {{ type_string() }}) as name
+    cast(null as {{ type_string() }}) as name,
+    cast(null as {{ type_string() }}) as alias
 from dummy_cte
 where 1 = 0

--- a/models/sources/snapshots.sql
+++ b/models/sources/snapshots.sql
@@ -10,12 +10,12 @@ select
     cast(null as {{ type_string() }}) as database,
     cast(null as {{ type_string() }}) as schema,
     cast(null as {{ type_string() }}) as name,
-    cast(null as {{ type_string() }}) as alias,
     cast(null as {{ type_array() }}) as depends_on_nodes,
     cast(null as {{ type_string() }}) as package_name,
     cast(null as {{ type_string() }}) as path,
     cast(null as {{ type_string() }}) as checksum,
     cast(null as {{ type_string() }}) as strategy,
-    cast(null as {{ type_json() }}) as meta
+    cast(null as {{ type_json() }}) as meta,
+    cast(null as {{ type_string() }}) as alias
 from dummy_cte
 where 1 = 0

--- a/models/sources/snapshots.sql
+++ b/models/sources/snapshots.sql
@@ -10,6 +10,7 @@ select
     cast(null as {{ type_string() }}) as database,
     cast(null as {{ type_string() }}) as schema,
     cast(null as {{ type_string() }}) as name,
+    cast(null as {{ type_string() }}) as alias,
     cast(null as {{ type_array() }}) as depends_on_nodes,
     cast(null as {{ type_string() }}) as package_name,
     cast(null as {{ type_string() }}) as path,

--- a/models/staging/stg_dbt__model_executions.sql
+++ b/models/staging/stg_dbt__model_executions.sql
@@ -24,7 +24,8 @@ enhanced as (
         {% endif %}
         materialization,
         schema, -- noqa
-        name
+        name,
+        alias
     from base
 
 )

--- a/models/staging/stg_dbt__model_executions.yml
+++ b/models/staging/stg_dbt__model_executions.yml
@@ -14,6 +14,8 @@ models:
     description: '{{ doc("model_execution_id") }}'
   - name: name
     description: '{{ doc("name") }}'
+  - name: alias
+    description: '{{ doc("alias") }}'
   - name: node_id
     description: '{{ doc("node_id") }}'
   - name: query_completed_at

--- a/models/staging/stg_dbt__models.sql
+++ b/models/staging/stg_dbt__models.sql
@@ -15,14 +15,14 @@ enhanced as (
         database,
         schema,
         name,
-        alias,
         depends_on_nodes,
         package_name,
         path,
         checksum,
         materialization,
         tags,
-        meta
+        meta,
+        alias
     from base
 
 )

--- a/models/staging/stg_dbt__models.sql
+++ b/models/staging/stg_dbt__models.sql
@@ -15,6 +15,7 @@ enhanced as (
         database,
         schema,
         name,
+        alias,
         depends_on_nodes,
         package_name,
         path,

--- a/models/staging/stg_dbt__models.yml
+++ b/models/staging/stg_dbt__models.yml
@@ -18,6 +18,8 @@ models:
     description: '{{ doc("model_execution_id") }}'
   - name: name
     description: '{{ doc("name") }}'
+  - name: alias
+    description: '{{ doc("alias") }}'
   - name: node_id
     description: '{{ doc("node_id") }}'
   - name: package_name

--- a/models/staging/stg_dbt__seed_executions.sql
+++ b/models/staging/stg_dbt__seed_executions.sql
@@ -21,7 +21,8 @@ enhanced as (
         rows_affected,
         materialization,
         schema, -- noqa
-        name
+        name,
+        alias
     from base
 
 )

--- a/models/staging/stg_dbt__seed_executions.yml
+++ b/models/staging/stg_dbt__seed_executions.yml
@@ -12,6 +12,8 @@ models:
     description: '{{ doc("materialization") }}'
   - name: name
     description: '{{ doc("name") }}'
+  - name: alias
+    description: '{{ doc("alias") }}'
   - name: node_id
     description: '{{ doc("node_id") }}'
   - name: query_completed_at

--- a/models/staging/stg_dbt__seeds.sql
+++ b/models/staging/stg_dbt__seeds.sql
@@ -15,11 +15,11 @@ enhanced as (
         database,
         schema,
         name,
-        alias,
         package_name,
         path,
         checksum,
-        meta
+        meta,
+        alias
     from base
 
 )

--- a/models/staging/stg_dbt__seeds.sql
+++ b/models/staging/stg_dbt__seeds.sql
@@ -15,6 +15,7 @@ enhanced as (
         database,
         schema,
         name,
+        alias,
         package_name,
         path,
         checksum,

--- a/models/staging/stg_dbt__seeds.yml
+++ b/models/staging/stg_dbt__seeds.yml
@@ -12,6 +12,8 @@ models:
     description: '{{ doc("database") }}'
   - name: name
     description: '{{ doc("name") }}'
+  - name: alias
+    description: '{{ doc("alias") }}'
   - name: node_id
     description: '{{ doc("node_id") }}'
   - name: package_name

--- a/models/staging/stg_dbt__snapshot_executions.sql
+++ b/models/staging/stg_dbt__snapshot_executions.sql
@@ -21,7 +21,8 @@ enhanced as (
         rows_affected,
         materialization,
         schema, -- noqa
-        name
+        name,
+        alias
     from base
 
 )

--- a/models/staging/stg_dbt__snapshot_executions.yml
+++ b/models/staging/stg_dbt__snapshot_executions.yml
@@ -12,6 +12,8 @@ models:
     description: '{{ doc("materialization") }}'
   - name: name
     description: '{{ doc("name") }}'
+  - name: alias
+    description: '{{ doc("alias") }}'
   - name: node_id
     description: '{{ doc("node_id") }}'
   - name: query_completed_at

--- a/models/staging/stg_dbt__snapshots.sql
+++ b/models/staging/stg_dbt__snapshots.sql
@@ -15,6 +15,7 @@ enhanced as (
         database,
         schema,
         name,
+        alias,
         depends_on_nodes,
         package_name,
         path,

--- a/models/staging/stg_dbt__snapshots.sql
+++ b/models/staging/stg_dbt__snapshots.sql
@@ -15,13 +15,13 @@ enhanced as (
         database,
         schema,
         name,
-        alias,
         depends_on_nodes,
         package_name,
         path,
         checksum,
         strategy,
-        meta
+        meta,
+        alias
     from base
 
 )

--- a/models/staging/stg_dbt__snapshots.yml
+++ b/models/staging/stg_dbt__snapshots.yml
@@ -14,6 +14,8 @@ models:
     description: '{{ doc("depends_on_nodes") }}'
   - name: name
     description: '{{ doc("name") }}'
+  - name: alias
+    description: '{{ doc("alias") }}'
   - name: node_id
     description: '{{ doc("node_id") }}'
   - name: package_name

--- a/models/staging/stg_dbt__snapshots.yml
+++ b/models/staging/stg_dbt__snapshots.yml
@@ -14,8 +14,6 @@ models:
     description: '{{ doc("depends_on_nodes") }}'
   - name: name
     description: '{{ doc("name") }}'
-  - name: alias
-    description: '{{ doc("alias") }}'
   - name: node_id
     description: '{{ doc("node_id") }}'
   - name: package_name
@@ -30,3 +28,5 @@ models:
     description: '{{ doc("snapshot_execution_id") }}'
   - name: strategy
     description: '{{ doc("strategy") }}'
+  - name: alias
+    description: '{{ doc("alias") }}'


### PR DESCRIPTION
Adds dbt alias to artifact uploads where applicable. Only tested in GCP/BigQuery as I don't have access to the other environments.

Useful in order to get the actual table/view name of a dbt model in case you use alias as the model name only matches to the table/view name in case you don't use an alias