### PR TITLE
Fix escape slash in invocation_args

### DIFF
--- a/macros/upload_invocations.sql
+++ b/macros/upload_invocations.sql
@@ -63,7 +63,7 @@
             null, {# dbt_vars #}
         {% endif %}
 
-        '{{ tojson(invocation_args_dict) }}', {# invocation_args #}
+        '{{ tojson(invocation_args_dict) | replace('\\', '\\\\') }}', {# invocation_args #}
         '{{ tojson(dbt_metadata_envs) }}' {# dbt_custom_envs #}
 
     )


### PR DESCRIPTION
Fix escape slash in `upload_invocations` 
example Json that was failing with `Error parsing JSON: hex digit is expected in \U???????? escape sequence, pos 153`:
```
'{"write_json": true, "use_colors": true, "printer_width": 80, "version_check": true, "partial_parse": true, "static_parser": true, "profiles_dir": "C:\\Users\\w500239\\.dbt", "send_anonymous_usage_stats": true, "event_buffer_size": 100000, "quiet": false, "no_print": false, "cache_selected_only": true, "target": "sub", "selector_name": "lexis_nexis", "which": "run", "rpc_method": "run", "indirect_selection": "eager"}',
```