### PR TITLE
Add entire model config object

### DIFF
--- a/macros/upload_models.sql
+++ b/macros/upload_models.sql
@@ -73,7 +73,7 @@
                     {{ tojson(model.tags) }}, {# tags #}
                     parse_json('{{ tojson(model.config.meta) }}'), {# meta #}
                     '{{ model.alias }}' {# alias #},
-                    {{ tojson(model.config) }} {# config #}
+                    parse_json('{{ tojson(model.config) }}') {# config #}
                 )
                 {%- if not loop.last %},{%- endif %}
             {%- endfor %}

--- a/macros/upload_models.sql
+++ b/macros/upload_models.sql
@@ -24,7 +24,8 @@
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(11) }},
             {{ adapter.dispatch('parse_json', 'dbt_artifacts')(adapter.dispatch('column_identifier', 'dbt_artifacts')(12)) }},
             {{ adapter.dispatch('parse_json', 'dbt_artifacts')(adapter.dispatch('column_identifier', 'dbt_artifacts')(13)) }},
-            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(14) }}
+            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(14) }},
+            {{ adapter.dispatch('parse_json', 'dbt_artifacts')(adapter.dispatch('column_identifier', 'dbt_artifacts')(15)) }}
         from values
         {% for model in models -%}
             (
@@ -41,7 +42,8 @@
                 '{{ model.config.materialized }}', {# materialization #}
                 '{{ tojson(model.tags) }}', {# tags #}
                 '{{ tojson(model.config.meta) }}', {# meta #}
-                '{{ model.alias }}' {# alias #}
+                '{{ model.alias }}', {# alias #}
+                '{{ tojson(model.config) }}' {# config #}
             )
             {%- if not loop.last %},{%- endif %}
         {%- endfor %}
@@ -70,7 +72,8 @@
                     '{{ model.config.materialized }}', {# materialization #}
                     {{ tojson(model.tags) }}, {# tags #}
                     parse_json('{{ tojson(model.config.meta) }}'), {# meta #}
-                    '{{ model.alias }}' {# alias #}
+                    '{{ model.alias }}' {# alias #},
+                    {{ tojson(model.config) }} {# config #}
                 )
                 {%- if not loop.last %},{%- endif %}
             {%- endfor %}

--- a/models/dim_dbt__models.sql
+++ b/models/dim_dbt__models.sql
@@ -22,7 +22,8 @@ models as (
         materialization,
         tags,
         meta,
-        alias
+        alias,
+        config
     from base
 
 )

--- a/models/dim_dbt__models.yml
+++ b/models/dim_dbt__models.yml
@@ -34,3 +34,5 @@ models:
     description: '{{ doc("meta") }}'
   - name: alias
     description: '{{ doc("alias") }}'
+  - name: config
+    description: '{{ doc("config") }}'

--- a/models/docs.md
+++ b/models/docs.md
@@ -394,3 +394,9 @@ Key-value pairs of environment variables passed to invocation that have the pref
 Alias of the node.
 
 {% enddocs %}
+
+{% docs config %}
+
+Config object for the node.
+
+{% enddocs %}

--- a/models/sources/models.sql
+++ b/models/sources/models.sql
@@ -17,6 +17,7 @@ select
     cast(null as {{ type_string() }}) as materialization,
     cast(null as {{ type_array() }}) as tags,
     cast(null as {{ type_json() }}) as meta,
-    cast(null as {{ type_string() }}) as alias
+    cast(null as {{ type_string() }}) as alias,
+    cast(null as {{ type_json() }}) as config
 from dummy_cte
 where 1 = 0

--- a/models/staging/stg_dbt__models.sql
+++ b/models/staging/stg_dbt__models.sql
@@ -22,7 +22,8 @@ enhanced as (
         materialization,
         tags,
         meta,
-        alias
+        alias,
+        config
     from base
 
 )

--- a/models/staging/stg_dbt__models.yml
+++ b/models/staging/stg_dbt__models.yml
@@ -34,3 +34,7 @@ models:
     description: '{{ doc("tags") }}'
   - name: meta
     description: '{{ doc("meta") }}'
+  - name: alias
+    description: '{{ doc("alias") }}'
+  - name: config
+    description: '{{ doc("config") }}'


### PR DESCRIPTION
Rather than having to add a new column for each config key (which can vary between adapter), it makes sense to just add the whole config object.