### PR TITLE
Fix insertion macro for Databricks Unity Catalog

### DIFF
--- a/macros/insert_into_metadata_table.sql
+++ b/macros/insert_into_metadata_table.sql
@@ -6,7 +6,7 @@
 
 {% macro spark__insert_into_metadata_table(database_name, schema_name, table_name, content) -%}
     {% set insert_into_table_query %}
-    insert into {{ database_name }}.{{ schema_name }}.{{ table_name }}
+    insert into {% if database_name %}{{ database_name }}.{% endif %}{{ schema_name }}.{{ table_name }}
     {{ content }}
     {% endset %}
 

--- a/macros/insert_into_metadata_table.sql
+++ b/macros/insert_into_metadata_table.sql
@@ -6,7 +6,7 @@
 
 {% macro spark__insert_into_metadata_table(database_name, schema_name, table_name, content) -%}
     {% set insert_into_table_query %}
-    insert into {{ schema_name }}.{{ table_name }}
+    insert into {{ database_name }}.{{ schema_name }}.{{ table_name }}
     {{ content }}
     {% endset %}
 


### PR DESCRIPTION
This PR fixes an issue for Databricks projects with Unity Catalog enabled. 
Currently, the `insert_into_metadata_table` macro only specifies the `schema_name.table_name`, but with catalogs (databases) introduced in Unity Catalog, the `database_name` is also required or the insertion fails.
This _should_ be backwards compatible with non-UC implementations of databricks since they can now also be fully qualified with a `database_name` of `hive_metastore` - assuming this value gets populated automatically, of course.

If there are any issues with non-UC implementations of databricks, or spark since it also shares this macro, an alternate solution would be to first check that the `database_name` has a value, and if so use it, otherwise just keep `schema_name.table_name`