### PR TITLE
fix parsing of dbt vars in bigquery

### DIFF
--- a/macros/upload_invocations.sql
+++ b/macros/upload_invocations.sql
@@ -112,6 +112,12 @@
             null, {# dbt_vars #}
         {% endif %}
 
+        {% if invocation_args_dict.vars %}
+            {# BigQuery does not handle the yaml-string from "--vars" well, when passed to "parse_json". Workaround is to parse the string, and then "tojson" will properly format the dict as a json-object. #}
+            {% set parsed_inv_args_vars = fromyaml(invocation_args_dict.vars) %}
+            {% do invocation_args_dict.update({'vars': parsed_inv_args_vars}) %}
+        {% endif %}
+
         parse_json('{{ tojson(invocation_args_dict) }}'), {# invocation_args #}
         parse_json('{{ tojson(dbt_metadata_envs) }}') {# dbt_custom_envs #}
 

--- a/tox.ini
+++ b/tox.ini
@@ -134,7 +134,7 @@ changedir = integration_test_project
 deps = dbt-bigquery~=1.3.0
 commands =
     dbt deps
-    dbt build --target bigquery
+    dbt build --target bigquery --vars '"my_var": "my value"'
 
 [testenv:integration_spark]
 changedir = integration_test_project


### PR DESCRIPTION
This closes #261.

This has been tested with running all three variants of passing variables to DBT from the CLI:
```
dbt run --vars '{"key": "value", "date": 20180101}'
dbt run --vars '{key: value, date: 20180101}'
dbt run --vars 'key: value'
```