### PR TITLE
Update sqlfluff to 2.0.2 & freeze version

### DIFF
--- a/models/sources/sources.sql
+++ b/models/sources/sources.sql
@@ -14,7 +14,7 @@ select
     cast(null as {{ type_string() }}) as name,
     cast(null as {{ type_string() }}) as identifier,
     cast(null as {{ type_string() }}) as loaded_at_field,
-    {% if target.type == 'snowflake'%}
+    {% if target.type == 'snowflake' %}
         cast(null as {{ type_array() }}) as freshness
     {% else %}
         cast(null as {{ type_json() }}) as freshness

--- a/tox.ini
+++ b/tox.ini
@@ -5,66 +5,63 @@ envlist = lint_all
 [sqlfluff]
 dialect = snowflake
 templater = dbt
-rules = L001,L003,L004,L005,L006,L007,L008,L010,L011,L012,L014,L015,L017,L018,L021,L022,L023,L025,L027,L028,L030,L035,L036,L037,L039,L040,L041,L042,L045,L046,L048,L051,L055
+rules = LT01,LT02,LT03,CP01,AL01,AL02,CP02,ST08,LT06,LT07,AM01,LT08,AL05,RF02,RF03,CP03,ST01,LT09,AM03,CP04,LT10,ST05,ST03,JJ01,AM05,CV08
 
-# L001 Unnecessary trailing whitespace, sqlfluff fix compatible. # https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L001
-# L003 Indentation not consistent with previous lines, sqlfluff fix compatible. # https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L003
-# L004 Indentation should be with spaces, not tabs, sqlfluff fix compatible. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L004
-# L005 Commas should not have whitespace directly before them, sqlfluff fix compatible. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L005
-# L006 Operators should be surrounded by a single whitespace, sqlfluff fix compatible. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L006
-# L007 Operators should be after newlines. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L007
-# L008 Commas should be followed by a single whitespace unless followed by a comment, sqlfluff fix compatible. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L008
-# L010 Inconsistent capitalisation of keywords, sqlfluff fix compatible. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L010
-# L011 Implicit/explicit aliasing of table, sqlfluff fix compatible. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L011
-# L012 Implicit/explicit aliasing of columns. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L012
-# L014 Inconsistent capitalisation of unquoted identifiers, sqlfluff fix compatible. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L014
-# L015 DISTINCT used with parentheses, sqlfluff fix compatible. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L015
-# L017 Function name not immediately followed by bracket, sqlfluff fix compatible. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L017
-# L018 WITH clause closing bracket should be aligned with WITH keyword, sqlfluff fix compatible. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L018
-# L021 Ambiguous use of DISTINCT in select statement with GROUP BY. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L021
-# L022 Blank line expected but not found after CTE closing bracket, sqlfluff fix compatible. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L022
-# L023 Single whitespace expected after AS in WITH clause, sqlfluff fix compatible. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L023
-# L025 Tables should not be aliased if that alias is not used, sqlfluff fix compatible. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L025
-# L027 References should be qualified if select has more than one referenced table/view. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L027
-# L028 References should be consistent in statements with a single table. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L028
-# L030 Inconsistent capitalisation of function names, sqlfluff fix compatible. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L030
-# L035 Do not specify "else null" in a case when statement (redundant), sqlfluff fix compatible. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L035
-# L036 Select targets should be on a new line unless there is only one select target, sqlfluff fix compatible. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L036
-# L037 Ambiguous ordering directions for columns in order by clause, sqlfluff fix compatible. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L037
-# L039 Unnecessary whitespace found, sqlfluff fix compatible. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L039
-# L040 Inconsistent capitalisation of boolean/null literal. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L040
-# L041 SELECT clause modifiers such as DISTINCT must be on the same line as SELECT, sqlfluff fix compatible. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L041
-# L042 Join/From clauses should not contain subqueries. Use CTEs instead. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L042
-# L045 Query defines a CTE (common-table expression) but does not use it, sqlfluff fix compatible. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L045
-# L046 Jinja tags should have a single whitespace on either side. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L046
-# L048 Quoted literals should be surrounded by a single whitespace, sqlfluff fix compatible. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L048
-# L051 INNER JOIN must be fully qualified, sqlfluff fix compatible. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L051
-# L055 Use LEFT JOIN instead of RIGHT JOIN. https://docs.sqlfluff.com/en/stable/rules.html#sqlfluff.core.rules.Rule_L055
+# LT01: [aliasing.table] Implicit/explicit aliasing of table.
+# AL02: [aliasing.column] Implicit/explicit aliasing of columns.
+# AL05: [aliasing.unused] Tables should not be aliased if that alias is not used.
+# AM01: [ambiguous.distinct] Ambiguous use of 'DISTINCT' in a 'SELECT' statement with 'GROUP BY'.
+# AM03: [ambiguous.order_by] Ambiguous ordering directions for columns in order by clause.
+# AM05: [ambiguous.join] Join clauses should be fully qualified.
+# CP01: [capitalisation.keywords] Inconsistent capitalisation of keywords.
+# CP02: [capitalisation.identifiers] Inconsistent capitalisation of unquoted identifiers.
+# CP03: [capitalisation.functions] Inconsistent capitalisation of function names.
+# CP04: [capitalisation.literals] Inconsistent capitalisation of boolean/null literal.
+# CV08: [convention.left_join] Use 'LEFT JOIN' instead of 'RIGHT JOIN'.
+# JJ01: [jinja.padding] Jinja tags should have a single whitespace on either side.
+# LT01: [layout.spacing] Inappropriate Spacing.
+# LT02: [layout.indent] Incorrect Indentation.
+# LT03: [layout.operators] Operators should follow a standard for being before/after newlines.
+# LT06: [layout.functions] Function name not immediately followed by parenthesis.
+# LT07: [layout.functions] 'WITH' clause closing bracket should be on a new line.
+# LT08: [layout.cte_newline] Blank line expected but not found after CTE closing bracket.
+# LT09: [layout.select_targets] Select targets should be on a new line unless there is only one select target.
+# LT10: [layout.select_modifiers] 'SELECT' modifiers (e.g. 'DISTINCT') must be on the same line as 'SELECT'.
+# RF02: [references.qualification] References should be qualified if select has more than one referenced table/view.
+# RF03: [references.consistent] References should be consistent in statements with a single table.
+# ST01: [structure.else_null] Do not specify 'else null' in a case when statement (redundant).
+# ST03: [structure.unused_cte] Query defines a CTE (common-table expression) but does not use it.
+# ST05: [structure.subquery] Join/From clauses should not contain subqueries. Use CTEs instead.
+# ST08: [structure.distinct] 'DISTINCT' used with parentheses.
 
 deps =
-    sqlfluff-templater-dbt
+    sqlfluff-templater-dbt~=2.0.2
     dbt-snowflake~=1.3.0
 
-[sqlfluff:rules:L004]
+[sqlfluff:indentation]
 indent_unit = space
 tab_space_size = 4
 
-[sqlfluff:rules:L010]
+[sqlfluff:layout:type:comma]
+spacing_before = touch
+line_position = leading
+
+[sqlfluff:rules:capitalisation.keywords]
 capitalisation_policy = lower
 
-[sqlfluff:rules:L014]
+[sqlfluff:rules:capitalisation.identifiers]
 capitalisation_policy = lower
 
-[sqlfluff:rules:L028]
+[sqlfluff:rules:references.consistent]
 single_table_references = unqualified
 
-[sqlfluff:rules:L030]
+[sqlfluff:rules:capitalisation.functions]
 capitalisation_policy = lower
 
-[sqlfluff:rules:L040]
+[sqlfluff:rules:capitalisation.literals]
 capitalisation_policy = lower
 
-[sqlfluff:rules:L042]
+[sqlfluff:rules:structure.subquery]
 forbid_subquery_in = both
 
 [sqlfluff:templater:dbt]


### PR DESCRIPTION
SQLfluff check was broken since the release of 2.0 as we didn't update `tox.ini` or freeze the SQLfluff version. In this PR I've updated the ruleset without changing the existing models (except for one teeny bug) and froze sqlfluff to 2.0.2