### PR TITLE
Update bigquery__get_invocations_dml_sql to use safe.parse_json for i…

### DIFF
--- a/macros/upload_invocations.sql
+++ b/macros/upload_invocations.sql
@@ -117,8 +117,8 @@
             {% set parsed_inv_args_vars = fromyaml(invocation_args_dict.vars) %}
             {% do invocation_args_dict.update({'vars': parsed_inv_args_vars}) %}
         {% endif %}
-
-        parse_json('{{ tojson(invocation_args_dict) }}'), {# invocation_args #}
+        {# invocation_args_dict.vars, in the absence of any vars, results in the value "{}\n" as a string which results in an error. safe.parse_json accomodates for this gracefully. #}
+        safe.parse_json('{{ tojson(invocation_args_dict) }}'), {# invocation_args #}
         parse_json('{{ tojson(dbt_metadata_envs) }}') {# dbt_custom_envs #}
 
         )


### PR DESCRIPTION
…nvocation args


## Overview

<!-- In 1-2 sentences, provide an overview of what this PR does -->

## Update type - breaking / non-breaking

<!-- What type of update is this? -->
- [x] Minor bug fix
- [ ] Documentation improvements
- [ ] Quality of Life improvements
- [ ] New features (non-breaking change)
- [ ] New features (breaking change)
- [ ] Other (non-breaking change)
- [ ] Other (breaking change)

## What does this solve?
In `bigquery__get_invocations_dml_sql`, if no variables were provided for this invocation, then the bigquery-specific code for handling yaml results in an error. `invocation_args_dict.vars`, in the absence of any `--vars` usage, results in the value "{}\n" as a string for this field, which results in an error for `PARSE_JSON`. safe.parse_json accommodates for this gracefully.

Here is the error that was being received:
```
Invalid input: syntax error while parsing value - invalid string: control character U+000A (LF) must be escaped to \u000A or \n; last read: '"{}<U+000A>'; error in PARSE_JSON expression
```

<!-- Include any links to relevant open issues -->

## Outstanding questions

<!-- Include any details here of issues you found along the way, or things that still require attention -->

## What databases have you tested with?

<!-- You don't need to have tested with them all, but this helps us know which you have tried already -->
- [ ] Snowflake
- [x] Google BigQuery
- [ ] Databricks
- [ ] Spark
- [ ] N/A
