### PR TITLE
Add double CI run - first on latest release then on PR

### DIFF
--- a/.github/workflows/ci_test_package.yml
+++ b/.github/workflows/ci_test_package.yml
@@ -27,82 +27,57 @@ env:
   TEST_ENV_VAR_1: TEST_VALUE
   DBT_ENV_CUSTOM_ENV_FAVOURITE_DBT_PACKAGE: dbt_artifacts
 
-
 jobs:
-  integration-snowflake:
-    runs-on: ubuntu-latest
-    environment:
-      name: Approve Integration Tests
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }} # Check out the code of the PR
-
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.8.x'
-          architecture: 'x64'
-
-      - name: Install tox
-        run: python3 -m pip install tox
-
-      - name: Run Snowflake Tests
-        run: tox -e integration_snowflake
-
-  integration-databricks:
-    runs-on: ubuntu-latest
-    environment:
-      name: Approve Integration Tests
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }} # Check out the code of the PR
-
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.8.x'
-          architecture: 'x64'
-
-      - name: Install tox
-        run: python3 -m pip install tox
-
-      - name: Run Databricks Tests
-        run: tox -e integration_databricks
-
-  integration-bigquery:
+  integration:
+    strategy:
+      matrix:
+        warehouse: ["snowflake", "databricks", "bigquery"]
     runs-on: ubuntu-latest
     environment:
       name: Approve Integration Tests
     permissions:
-      contents: 'read'
-      id-token: 'write'
+      contents: "read"
+      id-token: "write"
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - name: Get latest release
+        uses: rez0n/actions-github-release@main
+        id: latest_release
+        env:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          repository: ${{ github.repository }}
+          type: "stable"
+
+      - name: Checkout latest release
+        uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.head.sha }} # Check out the code of the PR
+          ref: ${{ steps.latest_release.outputs.release }}
 
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.8.x'
-          architecture: 'x64'
+          python-version: "3.8.x"
+          architecture: "x64"
 
       - name: Install tox
         run: python3 -m pip install tox
 
       - id: auth
+        if: ${{ matrix.warehouse == 'bigquery' }}
         uses: google-github-actions/auth@v0.4.0
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
-      - name: Run BigQuery Tests
-        run: tox -e integration_bigquery
+      - name: Run Tests on latest release
+        run: tox -e integration_${{ matrix.warehouse }}
+
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }} # Check out the code of the PR
+
+      - name: Run Tests on PR
+        run: tox -e integration_${{ matrix.warehouse }}
 
   sqlfluff-lint-models:
     name: Lint dbt models using SQLFluff
@@ -112,7 +87,7 @@ jobs:
 
     steps:
       - name: Checkout Branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }} # Check out the code of the PR
 
@@ -129,7 +104,7 @@ jobs:
         id: get_file_changes
         uses: trilom/file-changes-action@v1.2.4
         with:
-          output: ' '
+          output: " "
 
       - name: Get new and changed .sql files in /models to lint
         id: get_files_to_lint
@@ -163,4 +138,3 @@ jobs:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           title: "SQLFluff Lint"
           input: "./annotations.json"
-


### PR DESCRIPTION
## Overview

In the latest release, there were breaking changes that weren't flagged in the CI checks. Per #239, this aims to first run the tests on the latest release, then on the checked out code.

I've also moved this to use a matrix for simplicity.

## Update type - breaking / non-breaking

<!-- What type of update is this? -->
- [ ] Minor bug fix
- [ ] Documentation improvements
- [x] Quality of Life improvements
- [ ] New features (non-breaking change)
- [ ] New features (breaking change)
- [ ] Other (non-breaking change)
- [ ] Other (breaking change)

## What does this solve?

- Resolves #239 

## Outstanding questions

Need to double check they still work as expected.

## What databases have you tested with?

<!-- You don't need to have tested with them all, but this helps us know which you have tried already -->
- [ ] Snowflake
- [ ] Google BigQuery
- [ ] Databricks
- [ ] Spark
- [ ] N/A
