### PR TITLE
Feat/add tags to exposures

### DIFF
--- a/integration_test_project/models/tests_and_exposures.yml
+++ b/integration_test_project/models/tests_and_exposures.yml
@@ -15,6 +15,7 @@ exposures:
     maturity: high
     description: "ceo's favourite dashboard"
     url: https://bi.tool/dashboards/1
+    tags: ["ceo", "data"]
 
     depends_on:
       - ref('non_incremental')
@@ -28,6 +29,7 @@ exposures:
     maturity: high
     description: '{{ doc("clickstream") }}'
     url: https://bi.tool/dashboards/1
+    tags: ["cio", "it"]
 
     depends_on:
       - ref('incremental')

--- a/macros/upload_exposures.sql
+++ b/macros/upload_exposures.sql
@@ -22,7 +22,8 @@
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(9) }},
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(10) }},
             {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(11) }},
-            {{ adapter.dispatch('parse_json', 'dbt_artifacts')(adapter.dispatch('column_identifier', 'dbt_artifacts')(12)) }}
+            {{ adapter.dispatch('parse_json', 'dbt_artifacts')(adapter.dispatch('column_identifier', 'dbt_artifacts')(12)) }},
+            {{ adapter.dispatch('parse_json', 'dbt_artifacts')(adapter.dispatch('column_identifier', 'dbt_artifacts')(13)) }}
         from values
         {% for exposure in exposures -%}
             (
@@ -37,7 +38,8 @@
                 '{{ exposure.description | replace("'","\\'") }}', {# description #}
                 '{{ exposure.url }}', {# url #}
                 '{{ exposure.package_name }}', {# package_name #}
-                '{{ tojson(exposure.depends_on.nodes) }}' {# depends_on_nodes #}
+                '{{ tojson(exposure.depends_on.nodes) }}', {# depends_on_nodes #}
+                '{{ tojson(exposure.tags) }}' {# tags #}
             )
             {%- if not loop.last %},{%- endif %}
         {%- endfor %}
@@ -64,7 +66,9 @@
                     """{{ exposure.description | replace("'","\\'") }}""", {# description #}
                     '{{ exposure.url }}', {# url #}
                     '{{ exposure.package_name }}', {# package_name #}
-                    {{ tojson(exposure.depends_on.nodes) }} {# depends_on_nodes #}
+                    {{ tojson(exposure.depends_on.nodes) }}, {# depends_on_nodes #}
+                    {{ tojson(exposure.tags) }} {# tags #}
+
                 )
                 {%- if not loop.last %},{%- endif %}
             {%- endfor %}

--- a/models/dim_dbt__exposures.sql
+++ b/models/dim_dbt__exposures.sql
@@ -20,7 +20,8 @@ exposures as (
         description,
         url,
         package_name,
-        depends_on_nodes
+        depends_on_nodes,
+        tags
     from base
 
 )

--- a/models/dim_dbt__exposures.yml
+++ b/models/dim_dbt__exposures.yml
@@ -30,3 +30,5 @@ models:
     description: '{{ doc("type") }}'
   - name: url
     description: '{{ doc("url") }}'
+  - name: tags
+    description: '{{ doc("tags") }}'

--- a/models/sources/exposures.sql
+++ b/models/sources/exposures.sql
@@ -15,6 +15,7 @@ select
     cast(null as {{ type_string() }}) as description,
     cast(null as {{ type_string() }}) as url,
     cast(null as {{ type_string() }}) as package_name,
-    cast(null as {{ type_array() }}) as depends_on_nodes
+    cast(null as {{ type_array() }}) as depends_on_nodes,
+    cast(null as {{ type_array() }}) as tags
 from dummy_cte
 where 1 = 0

--- a/models/staging/stg_dbt__exposures.sql
+++ b/models/staging/stg_dbt__exposures.sql
@@ -20,7 +20,8 @@ enhanced as (
         description,
         url,
         package_name,
-        depends_on_nodes
+        depends_on_nodes,
+        tags
     from base
 
 )

--- a/models/staging/stg_dbt__exposures.yml
+++ b/models/staging/stg_dbt__exposures.yml
@@ -30,3 +30,5 @@ models:
     description: '{{ doc("type") }}'
   - name: url
     description: '{{ doc("url") }}'
+  - name: tags
+    description: '{{ doc("tags") }}'


### PR DESCRIPTION
## Overview

As requested in #253, this adds the `tags` field to the exposures table.

## Update type - breaking / non-breaking

<!-- What type of update is this? -->
- [ ] Minor bug fix
- [ ] Documentation improvements
- [ ] Quality of Life improvements
- [ ] New features (non-breaking change)
- [x] New features (breaking change)
- [ ] Other (non-breaking change)
- [ ] Other (breaking change)

## What does this solve?

- Resolves #253 

## Outstanding questions

N/A

## What databases have you tested with?

<!-- You don't need to have tested with them all, but this helps us know which you have tried already -->
- [x] Snowflake
- [ ] Google BigQuery
- [ ] Databricks
- [ ] Spark
- [ ] N/A
