### PR TITLE
Specify dbt version to `[">=1.3.0", "<1.5.0"]`

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
-name: 'dbt_artifacts'
-version: '2.3.0'
+name: "dbt_artifacts"
+version: "2.3.0"
 config-version: 2
-require-dbt-version: ">=1.3.0"
+require-dbt-version: [">=1.3.0", "<1.5.0"]
 profile: "dbt_artifacts"
 
 clean-targets: # folders to be removed by `dbt clean`


### PR DESCRIPTION
## Overview

It's clear this doesn't (currently) work with dbt v1.5, so this PR aims to restrict the version of dbt being used to stop before 1.5.

## Update type - breaking / non-breaking

<!-- What type of update is this? -->
- [ ] Minor bug fix
- [ ] Documentation improvements
- [ ] Quality of Life improvements
- [ ] New features (non-breaking change)
- [ ] New features (breaking change)
- [x] Other (non-breaking change)
- [ ] Other (breaking change)

## What does this solve?

This is a temporary solution and we will need to address the issues with 1.5 asap.

## Outstanding questions

N/A

## What databases have you tested with?

<!-- You don't need to have tested with them all, but this helps us know which you have tried already -->
- [ ] Snowflake
- [ ] Google BigQuery
- [ ] Databricks
- [ ] Spark
- [ ] N/A
