### PR TITLE
Fix BigQuery CI check

### DIFF
--- a/.github/workflows/ci_test_package.yml
+++ b/.github/workflows/ci_test_package.yml
@@ -79,6 +79,14 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }} # Check out the code of the PR
 
+      # Need to get the auth file again
+      - id: auth
+        if: ${{ matrix.warehouse == 'bigquery' }}
+        uses: google-github-actions/auth@v1
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
       - name: Run Tests on PR
         run: tox -e integration_${{ matrix.warehouse }}
 

--- a/.github/workflows/ci_test_package.yml
+++ b/.github/workflows/ci_test_package.yml
@@ -33,6 +33,7 @@ env:
 jobs:
   integration:
     strategy:
+      fail-fast: false # Don't fail one DWH if the others fail
       matrix:
         warehouse: ["snowflake", "databricks", "bigquery"]
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Overview

Issue with the BigQuery CI check - the auth file is deleted with the second run.

## Update type - breaking / non-breaking

<!-- What type of update is this? -->
- [ ] Minor bug fix
- [ ] Documentation improvements
- [ ] Quality of Life improvements
- [ ] New features (non-breaking change)
- [ ] New features (breaking change)
- [x] Other (non-breaking change)
- [ ] Other (breaking change)

## What does this solve?

Failing CI checks

## Outstanding questions

N/A

## What databases have you tested with?

<!-- You don't need to have tested with them all, but this helps us know which you have tried already -->
- [ ] Snowflake
- [ ] Google BigQuery
- [ ] Databricks
- [ ] Spark
- [x] N/A
