### PR TITLE
Fix bigquery quote issue with env vars

### DIFF
--- a/.github/workflows/ci_test_package.yml
+++ b/.github/workflows/ci_test_package.yml
@@ -33,6 +33,7 @@ env:
 jobs:
   integration:
     strategy:
+      fail-fast: false # Don't fail one DWH if the others fail
       matrix:
         warehouse: ["snowflake", "databricks", "bigquery"]
     runs-on: ubuntu-latest

--- a/macros/upload_invocations.sql
+++ b/macros/upload_invocations.sql
@@ -100,7 +100,7 @@
         {% if var('env_vars', none) %}
             {% set env_vars_dict = {} %}
             {% for env_variable in var('env_vars') %}
-                {% do env_vars_dict.update({env_variable: (env_var(env_variable, '') | replace("'", "\\'"))}) %}
+                {% do env_vars_dict.update({env_variable: (env_var(env_variable, '') | replace("'", "\\\\'"))}) %}
             {% endfor %}
             parse_json('{{ tojson(env_vars_dict) }}'), {# env_vars #}
         {% else %}
@@ -110,7 +110,7 @@
         {% if var('dbt_vars', none) %}
             {% set dbt_vars_dict = {} %}
             {% for dbt_var in var('dbt_vars') %}
-                {% do dbt_vars_dict.update({dbt_var: (var(dbt_var, '') | replace("'", "\\'"))}) %}
+                {% do dbt_vars_dict.update({dbt_var: (var(dbt_var, '') | replace("'", "\\\\'"))}) %}
             {% endfor %}
             parse_json('{{ tojson(dbt_vars_dict) }}'), {# dbt_vars #}
         {% else %}
@@ -126,7 +126,7 @@
         safe.parse_json('{{ tojson(invocation_args_dict) }}'), {# invocation_args #}
         {% set metadata_env = {} %}
         {% for key, value in dbt_metadata_envs.items() %}
-            {% do metadata_env.update({key: (value | replace("'", "\\'"))}) %}
+            {% do metadata_env.update({key: (value | replace("'", "\\\\'"))}) %}
         {% endfor %}
         parse_json('{{ tojson(metadata_env) | replace('\\', '\\\\') }}') {# dbt_custom_envs #}
 

--- a/macros/upload_invocations.sql
+++ b/macros/upload_invocations.sql
@@ -100,9 +100,9 @@
         {% if var('env_vars', none) %}
             {% set env_vars_dict = {} %}
             {% for env_variable in var('env_vars') %}
-                {% do env_vars_dict.update({env_variable: (env_var(env_variable, '') | replace("'", "\\\\'"))}) %}
+                {% do env_vars_dict.update({env_variable: (env_var(env_variable, ''))}) %}
             {% endfor %}
-            parse_json('{{ tojson(env_vars_dict) }}'), {# env_vars #}
+            parse_json('''{{ tojson(env_vars_dict) }}'''), {# env_vars #}
         {% else %}
             null, {# env_vars #}
         {% endif %}
@@ -110,9 +110,9 @@
         {% if var('dbt_vars', none) %}
             {% set dbt_vars_dict = {} %}
             {% for dbt_var in var('dbt_vars') %}
-                {% do dbt_vars_dict.update({dbt_var: (var(dbt_var, '') | replace("'", "\\\\'"))}) %}
+                {% do dbt_vars_dict.update({dbt_var: (var(dbt_var, ''))}) %}
             {% endfor %}
-            parse_json('{{ tojson(dbt_vars_dict) }}'), {# dbt_vars #}
+            parse_json('''{{ tojson(dbt_vars_dict) }}'''), {# dbt_vars #}
         {% else %}
             null, {# dbt_vars #}
         {% endif %}
@@ -123,12 +123,12 @@
             {% do invocation_args_dict.update({'vars': parsed_inv_args_vars}) %}
         {% endif %}
         {# invocation_args_dict.vars, in the absence of any vars, results in the value "{}\n" as a string which results in an error. safe.parse_json accomodates for this gracefully. #}
-        safe.parse_json('{{ tojson(invocation_args_dict) }}'), {# invocation_args #}
+        safe.parse_json('''{{ tojson(invocation_args_dict) }}'''), {# invocation_args #}
         {% set metadata_env = {} %}
         {% for key, value in dbt_metadata_envs.items() %}
-            {% do metadata_env.update({key: (value | replace("'", "\\\\'"))}) %}
+            {% do metadata_env.update({key: value}) %}
         {% endfor %}
-        parse_json('{{ tojson(metadata_env) | replace('\\', '\\\\') }}') {# dbt_custom_envs #}
+        parse_json('''{{ tojson(metadata_env) | replace('\\', '\\\\') }}''') {# dbt_custom_envs #}
 
         )
     {% endset %}

--- a/macros/upload_invocations.sql
+++ b/macros/upload_invocations.sql
@@ -100,7 +100,7 @@
         {% if var('env_vars', none) %}
             {% set env_vars_dict = {} %}
             {% for env_variable in var('env_vars') %}
-                {% do env_vars_dict.update({env_variable: (env_var(env_variable, '') | replace("'", "''"))}) %}
+                {% do env_vars_dict.update({env_variable: (env_var(env_variable, '') | replace("'", "\\'"))}) %}
             {% endfor %}
             parse_json('{{ tojson(env_vars_dict) }}'), {# env_vars #}
         {% else %}
@@ -110,7 +110,7 @@
         {% if var('dbt_vars', none) %}
             {% set dbt_vars_dict = {} %}
             {% for dbt_var in var('dbt_vars') %}
-                {% do dbt_vars_dict.update({dbt_var: (var(dbt_var, '') | replace("'", "''"))}) %}
+                {% do dbt_vars_dict.update({dbt_var: (var(dbt_var, '') | replace("'", "\\'"))}) %}
             {% endfor %}
             parse_json('{{ tojson(dbt_vars_dict) }}'), {# dbt_vars #}
         {% else %}
@@ -126,7 +126,7 @@
         safe.parse_json('{{ tojson(invocation_args_dict) }}'), {# invocation_args #}
         {% set metadata_env = {} %}
         {% for key, value in dbt_metadata_envs.items() %}
-            {% do metadata_env.update({key: (value | replace("'", "''"))}) %}
+            {% do metadata_env.update({key: (value | replace("'", "\\'"))}) %}
         {% endfor %}
         parse_json('{{ tojson(metadata_env) | replace('\\', '\\\\') }}') {# dbt_custom_envs #}
 


### PR DESCRIPTION
## Overview

When an environment variable has a single quote, Bigquery is unable to process it.

## Update type - breaking / non-breaking

<!-- What type of update is this? -->
- [x] Minor bug fix
- [ ] Documentation improvements
- [ ] Quality of Life improvements
- [ ] New features (non-breaking change)
- [ ] New features (breaking change)
- [ ] Other (non-breaking change)
- [ ] Other (breaking change)

## What does this solve?

None - identified in CI checks

## Outstanding questions

None

## What databases have you tested with?

<!-- You don't need to have tested with them all, but this helps us know which you have tried already -->
- [ ] Snowflake
- [ ] Google BigQuery
- [ ] Databricks
- [ ] Spark
- [x] N/A
