### PR TITLE
Remove source persist docs for databricks

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
-name: 'dbt_artifacts'
-version: '2.3.0'
+name: "dbt_artifacts"
+version: "2.3.0"
 config-version: 2
 require-dbt-version: ">=1.3.0"
 profile: "dbt_artifacts"
@@ -17,3 +17,6 @@ models:
       +materialized: incremental
       +on_schema_change: append_new_columns
       +full_refresh: false
+      +persist_docs:
+        # Databricks doesn't offer column-level support for persisting docs
+        columns: '{{ target.name != "databricks" }}'


### PR DESCRIPTION
## Overview

When the source tables are empty, Databricks complains about the column-level comments. This aims to remove this issue for Databricks.

## Update type - breaking / non-breaking

<!-- What type of update is this? -->
- [x] Minor bug fix
- [ ] Documentation improvements
- [ ] Quality of Life improvements
- [ ] New features (non-breaking change)
- [ ] New features (breaking change)
- [ ] Other (non-breaking change)
- [ ] Other (breaking change)

## What does this solve?

Failing CI issues

## Outstanding questions

Not sure how to test this - previously it worked fine with the CI checks, but only failed after merging to master.

## What databases have you tested with?

<!-- You don't need to have tested with them all, but this helps us know which you have tried already -->
- [ ] Snowflake
- [ ] Google BigQuery
- [ ] Databricks
- [ ] Spark
- [ ] N/A
