### PR TITLE
Fix issue with ' in meta field

### DIFF
--- a/integration_test_project/models/incremental.sql
+++ b/integration_test_project/models/incremental.sql
@@ -1,7 +1,8 @@
 {{
     config(
         materialized='incremental',
-        unique_key='id'
+        unique_key='id',
+        meta={"meta_field": "description with an ' apostrophe"},
     )
 }}
 

--- a/integration_test_project/models/incremental.sql
+++ b/integration_test_project/models/incremental.sql
@@ -1,4 +1,3 @@
-{# Meta field to test apostrophes are handled ok #}
 {{
     config(
         materialized='incremental',

--- a/integration_test_project/models/incremental.sql
+++ b/integration_test_project/models/incremental.sql
@@ -1,3 +1,4 @@
+{# Meta field to test apostrophes are handled ok #}
 {{
     config(
         materialized='incremental',

--- a/macros/upload_models.sql
+++ b/macros/upload_models.sql
@@ -41,7 +41,7 @@
                 '{{ model.checksum.checksum }}', {# checksum #}
                 '{{ model.config.materialized }}', {# materialization #}
                 '{{ tojson(model.tags) }}', {# tags #}
-                '{{ tojson(model.config.meta) }}', {# meta #}
+                '{{ tojson(model.config.meta) | replace("\\", "\\\\") | replace("'","\\'") | replace('"', '\\"') }}', {# meta #}
                 '{{ model.alias }}', {# alias #}
                 '{{ tojson(model) | replace("\\", "\\\\") | replace("'","\\'") | replace('"', '\\"') }}' {# all_results #}
             )
@@ -71,7 +71,7 @@
                     '{{ model.checksum.checksum }}', {# checksum #}
                     '{{ model.config.materialized }}', {# materialization #}
                     {{ tojson(model.tags) }}, {# tags #}
-                    parse_json('{{ tojson(model.config.meta) }}'), {# meta #}
+                    parse_json('''{{ tojson(model.config.meta) }}'''), {# meta #}
                     '{{ model.alias }}', {# alias #}
                     parse_json('{{ tojson(model) | replace("\\", "\\\\") | replace("'","\\'") | replace('"', '\\"') }}') {# all_results #}
                 )

--- a/macros/upload_seeds.sql
+++ b/macros/upload_seeds.sql
@@ -35,7 +35,7 @@
                 '{{ seed.package_name }}', {# package_name #}
                 '{{ seed.original_file_path | replace('\\', '\\\\') }}', {# path #}
                 '{{ seed.checksum.checksum }}', {# checksum #}
-                '{{ tojson(seed.config.meta) }}', {# meta #}
+                '{{ tojson(seed.config.meta) | replace("\\", "\\\\") | replace("'","\\'") | replace('"', '\\"') }}', {# meta #}
                 '{{ seed.alias }}', {# alias #}
                 '{{ tojson(seed) | replace("\\", "\\\\") | replace("'","\\'") | replace('"', '\\"') }}' {# all_results #}
             )
@@ -62,7 +62,7 @@
                     '{{ seed.package_name }}', {# package_name #}
                     '{{ seed.original_file_path | replace('\\', '\\\\') }}', {# path #}
                     '{{ seed.checksum.checksum }}', {# checksum #}
-                    parse_json('{{ tojson(seed.config.meta) }}'), {# meta #}
+                    parse_json('''{{ tojson(seed.config.meta) }}'''), {# meta #}
                     '{{ seed.alias }}', {# alias #}
                     parse_json('{{ tojson(seed) | replace("\\", "\\\\") | replace("'","\\'") | replace('"', '\\"') }}') {# all_results #}
                 )

--- a/macros/upload_snapshots.sql
+++ b/macros/upload_snapshots.sql
@@ -40,7 +40,7 @@
                 '{{ snapshot.original_file_path | replace('\\', '\\\\') }}', {# path #}
                 '{{ snapshot.checksum.checksum }}', {# checksum #}
                 '{{ snapshot.config.strategy }}', {# strategy #}
-                '{{ tojson(snapshot.config.meta) }}', {# meta #}
+                '{{ tojson(snapshot.config.meta) | replace("\\", "\\\\") | replace("'","\\'") | replace('"', '\\"') }}', {# meta #}
                 '{{ snapshot.alias }}', {# alias #}
                 '{{ tojson(snapshot) | replace("\\", "\\\\") | replace("'","\\'") | replace('"', '\\"') }}' {# all_results #}
             )
@@ -69,7 +69,7 @@
                     '{{ snapshot.original_file_path | replace('\\', '\\\\') }}', {# path #}
                     '{{ snapshot.checksum.checksum }}', {# checksum #}
                     '{{ snapshot.config.strategy }}', {# strategy #}
-                    parse_json('{{ tojson(snapshot.config.meta) }}'), {# meta #}
+                    parse_json('''{{ tojson(snapshot.config.meta) }}'''), {# meta #}
                     '{{ snapshot.alias }}', {# alias #}
                     parse_json('{{ tojson(snapshot) | replace("\\", "\\\\") | replace("'","\\'") | replace('"', '\\"') }}') {# all_results #}
                 )


### PR DESCRIPTION
## Overview

This aims to fix the issues when there is an apostrophe in the meta field. I have additionally added an example meta field within a model to test this.

Edit: as dbx CI checks are not currently running (see #342 ), I have confirmed that it runs locally using dbx on 1.4 and 1.5.

## Update type - breaking / non-breaking

<!-- What type of update is this? -->
- [x] Minor bug fix
- [ ] Documentation improvements
- [ ] Quality of Life improvements
- [ ] New features (non-breaking change)
- [ ] New features (breaking change)
- [ ] Other (non-breaking change)
- [ ] Other (breaking change)

## What does this solve?

- Resolves #258

## Outstanding questions

None

## What databases have you tested with?

<!-- You don't need to have tested with them all, but this helps us know which you have tried already -->
- [x] Snowflake
- [x] Google BigQuery
- [x] Databricks
- [ ] Spark
- [ ] N/A
