### PR TITLE
[Fix] Add max-parallel 1 to package test jobs

### DIFF
--- a/.github/workflows/ci_test_package.yml
+++ b/.github/workflows/ci_test_package.yml
@@ -33,6 +33,7 @@ env:
 jobs:
   integration:
     strategy:
+      max-parallel: 1
       fail-fast: false # Don't fail one DWH if the others fail
       matrix:
         warehouse: ["snowflake", "databricks", "bigquery"]
@@ -93,6 +94,7 @@ jobs:
 
   single-run-different-versions:
     strategy:
+      max-parallel: 1
       fail-fast: false # Don't fail one DWH if the others fail
       matrix:
         warehouse: ["snowflake", "databricks", "bigquery"]


### PR DESCRIPTION
## Overview

- With the current set up the test jobs run via Github Workflows are trying to write to the same tables.
- This PR limits the max parallel jobs to 1 so that we can still benefit from the Matrix templating of tests jobs but it will ensure the jobs run one after the other.
- Longer term plan is to remove this at a later date in favour of a more optimal set up for writing to different schemas.

## Update type - breaking / non-breaking

<!-- What type of update is this? -->
- [X] Minor bug fix
- [ ] Documentation improvements
- [ ] Quality of Life improvements
- [ ] New features (non-breaking change)
- [ ] New features (breaking change)
- [ ] Other (non-breaking change)
- [ ] Other (breaking change)

## What does this solve?

<!-- Include any links to relevant open issues -->

## Outstanding questions

<!-- Include any details here of issues you found along the way, or things that still require attention -->

## What databases have you tested with?

<!-- You don't need to have tested with them all, but this helps us know which you have tried already -->
- [] Snowflake
- [ ] Google BigQuery
- [ ] Databricks
- [ ] Spark
- [X] N/A
