### PR TITLE
Fix bigquery__get_invocations_dml_sql for dbt-bigquery 1.5

### DIFF
--- a/macros/upload_invocations.sql
+++ b/macros/upload_invocations.sql
@@ -124,6 +124,14 @@
         {% else %}
             null, {# dbt_vars #}
         {% endif %}
+        {% set keys_to_find =  ["event_buffer_size", "indirect_selection", "no_print", "partial_parse", "printer_width", "profiles_dir", "quiet", "rpc_method", "select", "send_anonymous_usage_stats", "static_parser", "use_colors", "version_check", "which", "profile", "defer", "exclude", "full_refresh", "write_json", "resource_types", "state", "target", "cache_selected_only", "compile"] %}
+        {% set new_invoke_args = {} %}
+        {% for key in keys_to_find %}
+            {% if key in invocation_args_dict | list  %}
+                {% do new_invoke_args.update({key: invocation_args_dict[key]}) %}
+            {% endif %}
+        {% endfor %}
+        {% set invocation_args_dict = new_invoke_args %}
 
         {% if invocation_args_dict.vars %}
             {# BigQuery does not handle the yaml-string from "--vars" well, when passed to "parse_json". Workaround is to parse the string, and then "tojson" will properly format the dict as a json-object. #}


### PR DESCRIPTION
## Overview

<!-- In 1-2 sentences, provide an overview of what this PR does -->


Similar to https://github.com/brooklyn-data/dbt_artifacts/issues/296 we are getting the same error when using dbt-bigquery 1.5.0. Making a similar change to the bigquery macro to [this commit](https://github.com/brooklyn-data/dbt_artifacts/pull/314/commits/348bb405de457a72044607ac05abef8c63b4af6e) solves the issue.

## Update type - breaking / non-breaking

<!-- What type of update is this? -->
- [x] Minor bug fix
- [ ] Documentation improvements
- [ ] Quality of Life improvements
- [ ] New features (non-breaking change)
- [ ] New features (breaking change)
- [ ] Other (non-breaking change)
- [ ] Other (breaking change)

## What does this solve?

Addresses: https://github.com/brooklyn-data/dbt_artifacts/issues/337

## What databases have you tested with?

<!-- You don't need to have tested with them all, but this helps us know which you have tried already -->
- [ ] Snowflake
- [x] Google BigQuery
- [ ] Databricks
- [ ] Spark
- [ ] N/A
