### PR TITLE
[FIX] Add character replacement to DBT_VERSION env var

### DIFF
--- a/.github/workflows/ci_test_package.yml
+++ b/.github/workflows/ci_test_package.yml
@@ -136,7 +136,7 @@ jobs:
         env:
           DBT_VERSION: ${{ matrix.version }}
         run: |
-          echo "DBT_VERSION=${{env.DBT_VERSION//./_}}" >> $GITHUB_ENV
+          echo "DBT_VERSION=${DBT_VERSION//./_}" >> $GITHUB_ENV
 
       - name: Run Tests on PR
         run: tox -e integration_${{ matrix.warehouse }}_${{ matrix.version }}

--- a/.github/workflows/ci_test_package.yml
+++ b/.github/workflows/ci_test_package.yml
@@ -78,7 +78,7 @@ jobs:
 
       - name: Character replacement in DBT_VERSION variable for use in schema
         run: |
-          echo "DBT_VERSION=${{env.LAST_RELEASE_SUPPORTED_DBT_VERSION//./_}}" >> $GITHUB_ENV
+          echo "DBT_VERSION=${{env.DBT_VERSION//./_}}" >> $GITHUB_ENV
 
       - name: Build tables for latest release
         run: tox -e integration_${{ matrix.warehouse }}_${{ env.LAST_RELEASE_SUPPORTED_DBT_VERSION }}
@@ -140,7 +140,7 @@ jobs:
 
       - name: Character replacement in DBT_VERSION variable for use in schema
         run: |
-          echo "DBT_VERSION=${{env.LAST_RELEASE_SUPPORTED_DBT_VERSION//./_}}" >> $GITHUB_ENV
+          echo "DBT_VERSION=${{env.DBT_VERSION//./_}}" >> $GITHUB_ENV
 
       - name: Run Tests on PR
         run: tox -e integration_${{ matrix.warehouse }}_${{ matrix.version }}

--- a/.github/workflows/ci_test_package.yml
+++ b/.github/workflows/ci_test_package.yml
@@ -44,8 +44,6 @@ jobs:
     permissions:
       contents: "read"
       id-token: "write"
-    env:
-      DBT_VERSION: ${{ env.LAST_RELEASE_SUPPORTED_DBT_VERSION }}
 
     steps:
       - name: Get latest release
@@ -76,11 +74,9 @@ jobs:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
-      - name: Character replacement in DBT_VERSION variable for use in schema
-        run: |
-          echo "DBT_VERSION=${{env.DBT_VERSION//./_}}" >> $GITHUB_ENV
-
       - name: Build tables for latest release
+        env:
+          DBT_VERSION: "noversion"
         run: tox -e integration_${{ matrix.warehouse }}_${{ env.LAST_RELEASE_SUPPORTED_DBT_VERSION }}
 
       - name: Checkout
@@ -113,8 +109,6 @@ jobs:
     permissions:
       contents: "read"
       id-token: "write"
-    env:
-      DBT_VERSION: ${{ matrix.version }}
 
     steps:
       - uses: actions/setup-python@v4
@@ -139,6 +133,8 @@ jobs:
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: Character replacement in DBT_VERSION variable for use in schema
+        env:
+          DBT_VERSION: ${{ matrix.version }}
         run: |
           echo "DBT_VERSION=${{env.DBT_VERSION//./_}}" >> $GITHUB_ENV
 

--- a/.github/workflows/ci_test_package.yml
+++ b/.github/workflows/ci_test_package.yml
@@ -76,6 +76,10 @@ jobs:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
+      - name: Character replacement in DBT_VERSION variable for use in schema
+        run: |
+          echo "DBT_VERSION=${{env.LAST_RELEASE_SUPPORTED_DBT_VERSION//./_}}" >> $GITHUB_ENV
+
       - name: Build tables for latest release
         run: tox -e integration_${{ matrix.warehouse }}_${{ env.LAST_RELEASE_SUPPORTED_DBT_VERSION }}
 
@@ -133,6 +137,10 @@ jobs:
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+
+      - name: Character replacement in DBT_VERSION variable for use in schema
+        run: |
+          echo "DBT_VERSION=${{env.LAST_RELEASE_SUPPORTED_DBT_VERSION//./_}}" >> $GITHUB_ENV
 
       - name: Run Tests on PR
         run: tox -e integration_${{ matrix.warehouse }}_${{ matrix.version }}

--- a/.github/workflows/main_test_package.yml
+++ b/.github/workflows/main_test_package.yml
@@ -62,5 +62,9 @@ jobs:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
+      - name: Character replacement in DBT_VERSION variable for use in schema
+        run: |
+          echo "DBT_VERSION=${{env.LAST_RELEASE_SUPPORTED_DBT_VERSION//./_}}" >> $GITHUB_ENV
+
       - name: Run ${{ matrix.warehouse }} Tests
         run: tox -e integration_${{ matrix.warehouse }}_${{ matrix.version }}

--- a/.github/workflows/main_test_package.yml
+++ b/.github/workflows/main_test_package.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Character replacement in DBT_VERSION variable for use in schema
         run: |
-          echo "DBT_VERSION=${{env.LAST_RELEASE_SUPPORTED_DBT_VERSION//./_}}" >> $GITHUB_ENV
+          echo "DBT_VERSION=${{env.DBT_VERSION//./_}}" >> $GITHUB_ENV
 
       - name: Run ${{ matrix.warehouse }} Tests
         run: tox -e integration_${{ matrix.warehouse }}_${{ matrix.version }}

--- a/.github/workflows/main_test_package.yml
+++ b/.github/workflows/main_test_package.yml
@@ -40,8 +40,6 @@ jobs:
     permissions:
       contents: "read"
       id-token: "write"
-    env:
-      DBT_VERSION: ${{ matrix.version }}
 
     steps:
       - name: Checkout
@@ -63,6 +61,8 @@ jobs:
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: Character replacement in DBT_VERSION variable for use in schema
+        env:
+          DBT_VERSION: ${{ matrix.version }}
         run: |
           echo "DBT_VERSION=${{env.DBT_VERSION//./_}}" >> $GITHUB_ENV
 

--- a/.github/workflows/main_test_package.yml
+++ b/.github/workflows/main_test_package.yml
@@ -64,7 +64,7 @@ jobs:
         env:
           DBT_VERSION: ${{ matrix.version }}
         run: |
-          echo "DBT_VERSION=${{env.DBT_VERSION//./_}}" >> $GITHUB_ENV
+          echo "DBT_VERSION=${DBT_VERSION//./_}" >> $GITHUB_ENV
 
       - name: Run ${{ matrix.warehouse }} Tests
         run: tox -e integration_${{ matrix.warehouse }}_${{ matrix.version }}


### PR DESCRIPTION
## Overview

- In my previous PR `DBT_VERSION` was used in the CI schemas
- It contains fullstops which cannot be used in schemas.
- This PR adds a job that will character replace fullstops for underscores for consistency with the rest of the schemas.
- This PR moves setting `DBT_VERSION` into `steps` from the `job` level
- Also sets DBT_VERSION in the integration job to `noversion` to avoid two 1.4.0 runs

## Update type - breaking / non-breaking

<!-- What type of update is this? -->
- [X] Minor bug fix
- [ ] Documentation improvements
- [ ] Quality of Life improvements
- [ ] New features (non-breaking change)
- [ ] New features (breaking change)
- [ ] Other (non-breaking change)
- [ ] Other (breaking change)

## What does this solve?

<!-- Include any links to relevant open issues -->

## Outstanding questions

<!-- Include any details here of issues you found along the way, or things that still require attention -->

## What databases have you tested with?

<!-- You don't need to have tested with them all, but this helps us know which you have tried already -->
- [X] Snowflake
- [ ] Google BigQuery
- [ ] Databricks
- [ ] Spark
- [ ] N/A
