### PR TITLE
Add underscores to versions, and non-versioned commands for CI

### DIFF
--- a/.github/workflows/ci_test_package.yml
+++ b/.github/workflows/ci_test_package.yml
@@ -21,7 +21,7 @@ env:
   DBT_ENV_SECRET_DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
   DBT_ENV_SECRET_GCP_PROJECT: ${{ secrets.GCP_PROJECT }}
   # Env var to test version
-  LAST_RELEASE_SUPPORTED_DBT_VERSION: 1.4.0 # A dbt version supported by both the last release and this one
+  LAST_RELEASE_SUPPORTED_DBT_VERSION: 1_4_0 # A dbt version supported by both the last release and this one
   # Env vars to test invocations model
   DBT_CLOUD_PROJECT_ID: 123
   DBT_CLOUD_JOB_ID: ABC
@@ -77,7 +77,7 @@ jobs:
       - name: Build tables for latest release
         env:
           DBT_VERSION: "noversion"
-        run: tox -e integration_${{ matrix.warehouse }}_${{ env.LAST_RELEASE_SUPPORTED_DBT_VERSION }}
+        run: tox -e integration_${{ matrix.warehouse }}
 
       - name: Checkout
         uses: actions/checkout@v3
@@ -102,7 +102,7 @@ jobs:
       matrix:
         warehouse: ["snowflake", "databricks", "bigquery"]
         # When supporting a new version, update the list here
-        version: ["1.3.0", "1.4.0", "1.5.0"]
+        version: ["1_3_0", "1_4_0", "1_5_0"]
     runs-on: ubuntu-latest
     environment:
       name: Approve Integration Tests
@@ -132,11 +132,7 @@ jobs:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
-      - name: Character replacement in DBT_VERSION variable for use in schema
+      - name: Run Tests on PR
         env:
           DBT_VERSION: ${{ matrix.version }}
-        run: |
-          echo "DBT_VERSION=${DBT_VERSION//./_}" >> $GITHUB_ENV
-
-      - name: Run Tests on PR
         run: tox -e integration_${{ matrix.warehouse }}_${{ matrix.version }}

--- a/.github/workflows/main_test_package.yml
+++ b/.github/workflows/main_test_package.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         warehouse: ["snowflake", "databricks", "bigquery"]
-        version: ["1.3.0", "1.4.0", "1.5.0"]
+        version: ["1_3_0", "1_4_0", "1_5_0"]
     runs-on: ubuntu-latest
     permissions:
       contents: "read"
@@ -60,11 +60,7 @@ jobs:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
-      - name: Character replacement in DBT_VERSION variable for use in schema
+      - name: Run ${{ matrix.warehouse }} Tests
         env:
           DBT_VERSION: ${{ matrix.version }}
-        run: |
-          echo "DBT_VERSION=${DBT_VERSION//./_}" >> $GITHUB_ENV
-
-      - name: Run ${{ matrix.warehouse }} Tests
         run: tox -e integration_${{ matrix.warehouse }}_${{ matrix.version }}

--- a/tox.ini
+++ b/tox.ini
@@ -122,7 +122,7 @@ commands = dbt docs generate --profiles-dir integration_test_project
 changedir = integration_test_project
 deps = dbt-snowflake~=1.4.0
 commands =
-    dbt deps
+    dbt clean && dbt deps
     dbt --debug build --target snowflake
 
 
@@ -130,21 +130,21 @@ commands =
 changedir = integration_test_project
 deps = dbt-snowflake~=1.3.0
 commands =
-    dbt deps
+    dbt clean && dbt deps
     dbt --debug build --target snowflake
 
 [testenv:integration_snowflake_1_4_0]
 changedir = integration_test_project
 deps = dbt-snowflake~=1.4.0
 commands =
-    dbt deps
+    dbt clean && dbt deps
     dbt --debug build --target snowflake
 
 [testenv:integration_snowflake_1_5_0]
 changedir = integration_test_project
 deps = dbt-snowflake~=1.5.0
 commands =
-    dbt deps
+    dbt clean && dbt deps
     dbt --debug build --target snowflake
 
 # Databricks integration tests
@@ -152,28 +152,28 @@ commands =
 changedir = integration_test_project
 deps = dbt-databricks~=1.4.0
 commands =
-    dbt deps
+    dbt clean && dbt deps
     dbt --debug build --target databricks
 
 [testenv:integration_databricks_1_3_0]
 changedir = integration_test_project
 deps = dbt-databricks~=1.3.0
 commands =
-    dbt deps
+    dbt clean && dbt deps
     dbt --debug build --target databricks
 
 [testenv:integration_databricks_1_4_0]
 changedir = integration_test_project
 deps = dbt-databricks~=1.4.0
 commands =
-    dbt deps
+    dbt clean && dbt deps
     dbt --debug build --target databricks
 
 [testenv:integration_databricks_1_5_0]
 changedir = integration_test_project
 deps = dbt-databricks~=1.5.0
 commands =
-    dbt deps
+    dbt clean && dbt deps
     dbt --debug build --target databricks
 
 # Bigquery integration tests
@@ -181,28 +181,28 @@ commands =
 changedir = integration_test_project
 deps = dbt-bigquery~=1.4.0
 commands =
-    dbt deps
+    dbt clean && dbt deps
     dbt --debug build --target bigquery --vars '"my_var": "my value"'
 
 [testenv:integration_bigquery_1_3_0]
 changedir = integration_test_project
 deps = dbt-bigquery~=1.3.0
 commands =
-    dbt deps
+    dbt clean && dbt deps
     dbt --debug build --target bigquery --vars '"my_var": "my value"'
 
 [testenv:integration_bigquery_1_4_0]
 changedir = integration_test_project
 deps = dbt-bigquery~=1.4.0
 commands =
-    dbt deps
+    dbt clean && dbt deps
     dbt --debug build --target bigquery --vars '"my_var": "my value"'
 
 [testenv:integration_bigquery_1_5_0]
 changedir = integration_test_project
 deps = dbt-bigquery~=1.5.0
 commands =
-    dbt deps
+    dbt clean && dbt deps
     dbt --debug build --target bigquery --vars '"my_var": "my value"'
 
 # Spark integration test (disabled)
@@ -210,6 +210,6 @@ commands =
 changedir = integration_test_project
 deps = dbt-spark[ODBC]~=1.4.0
 commands =
-    dbt deps
+    dbt clean && dbt deps
     dbt --debug build --exclude snapshot --target spark
 

--- a/tox.ini
+++ b/tox.ini
@@ -123,7 +123,7 @@ changedir = integration_test_project
 deps = dbt-snowflake~=1.4.0
 commands =
     dbt deps
-    dbt build --target snowflake
+    dbt --debug build --target snowflake
 
 
 [testenv:integration_snowflake_1_3_0]
@@ -131,21 +131,21 @@ changedir = integration_test_project
 deps = dbt-snowflake~=1.3.0
 commands =
     dbt deps
-    dbt build --target snowflake
+    dbt --debug build --target snowflake
 
 [testenv:integration_snowflake_1_4_0]
 changedir = integration_test_project
 deps = dbt-snowflake~=1.4.0
 commands =
     dbt deps
-    dbt build --target snowflake
+    dbt --debug build --target snowflake
 
 [testenv:integration_snowflake_1_5_0]
 changedir = integration_test_project
 deps = dbt-snowflake~=1.5.0
 commands =
     dbt deps
-    dbt build --target snowflake
+    dbt --debug build --target snowflake
 
 # Databricks integration tests
 [testenv:integration_databricks]
@@ -153,28 +153,28 @@ changedir = integration_test_project
 deps = dbt-databricks~=1.4.0
 commands =
     dbt deps
-    dbt build --target databricks
+    dbt --debug build --target databricks
 
 [testenv:integration_databricks_1_3_0]
 changedir = integration_test_project
 deps = dbt-databricks~=1.3.0
 commands =
     dbt deps
-    dbt build --target databricks
+    dbt --debug build --target databricks
 
 [testenv:integration_databricks_1_4_0]
 changedir = integration_test_project
 deps = dbt-databricks~=1.4.0
 commands =
     dbt deps
-    dbt build --target databricks
+    dbt --debug build --target databricks
 
 [testenv:integration_databricks_1_5_0]
 changedir = integration_test_project
 deps = dbt-databricks~=1.5.0
 commands =
     dbt deps
-    dbt build --target databricks
+    dbt --debug build --target databricks
 
 # Bigquery integration tests
 [testenv:integration_bigquery]
@@ -182,28 +182,28 @@ changedir = integration_test_project
 deps = dbt-bigquery~=1.4.0
 commands =
     dbt deps
-    dbt build --target bigquery --vars '"my_var": "my value"'
+    dbt --debug build --target bigquery --vars '"my_var": "my value"'
 
 [testenv:integration_bigquery_1_3_0]
 changedir = integration_test_project
 deps = dbt-bigquery~=1.3.0
 commands =
     dbt deps
-    dbt build --target bigquery --vars '"my_var": "my value"'
+    dbt --debug build --target bigquery --vars '"my_var": "my value"'
 
 [testenv:integration_bigquery_1_4_0]
 changedir = integration_test_project
 deps = dbt-bigquery~=1.4.0
 commands =
     dbt deps
-    dbt build --target bigquery --vars '"my_var": "my value"'
+    dbt --debug build --target bigquery --vars '"my_var": "my value"'
 
 [testenv:integration_bigquery_1_5_0]
 changedir = integration_test_project
 deps = dbt-bigquery~=1.5.0
 commands =
     dbt deps
-    dbt build --target bigquery --vars '"my_var": "my value"'
+    dbt --debug build --target bigquery --vars '"my_var": "my value"'
 
 # Spark integration test (disabled)
 [testenv:integration_spark]
@@ -211,5 +211,5 @@ changedir = integration_test_project
 deps = dbt-spark[ODBC]~=1.4.0
 commands =
     dbt deps
-    dbt build --exclude snapshot --target spark
+    dbt --debug build --exclude snapshot --target spark
 

--- a/tox.ini
+++ b/tox.ini
@@ -118,21 +118,29 @@ deps = dbt-snowflake~=1.5.0
 commands = dbt docs generate --profiles-dir integration_test_project
 
 # Snowflake integration tests
-[testenv:integration_snowflake_1.3.0]
-changedir = integration_test_project
-deps = dbt-snowflake~=1.3.0
-commands =
-    dbt deps
-    dbt build --target snowflake
-
-[testenv:integration_snowflake_1.4.0]
+[testenv:integration_snowflake]
 changedir = integration_test_project
 deps = dbt-snowflake~=1.4.0
 commands =
     dbt deps
     dbt build --target snowflake
 
-[testenv:integration_snowflake_1.5.0]
+
+[testenv:integration_snowflake_1_3_0]
+changedir = integration_test_project
+deps = dbt-snowflake~=1.3.0
+commands =
+    dbt deps
+    dbt build --target snowflake
+
+[testenv:integration_snowflake_1_4_0]
+changedir = integration_test_project
+deps = dbt-snowflake~=1.4.0
+commands =
+    dbt deps
+    dbt build --target snowflake
+
+[testenv:integration_snowflake_1_5_0]
 changedir = integration_test_project
 deps = dbt-snowflake~=1.5.0
 commands =
@@ -140,21 +148,28 @@ commands =
     dbt build --target snowflake
 
 # Databricks integration tests
-[testenv:integration_databricks_1.3.0]
-changedir = integration_test_project
-deps = dbt-databricks~=1.3.0
-commands =
-    dbt deps
-    dbt build --target databricks
-
-[testenv:integration_databricks_1.4.0]
+[testenv:integration_databricks]
 changedir = integration_test_project
 deps = dbt-databricks~=1.4.0
 commands =
     dbt deps
     dbt build --target databricks
 
-[testenv:integration_databricks_1.5.0]
+[testenv:integration_databricks_1_3_0]
+changedir = integration_test_project
+deps = dbt-databricks~=1.3.0
+commands =
+    dbt deps
+    dbt build --target databricks
+
+[testenv:integration_databricks_1_4_0]
+changedir = integration_test_project
+deps = dbt-databricks~=1.4.0
+commands =
+    dbt deps
+    dbt build --target databricks
+
+[testenv:integration_databricks_1_5_0]
 changedir = integration_test_project
 deps = dbt-databricks~=1.5.0
 commands =
@@ -162,21 +177,28 @@ commands =
     dbt build --target databricks
 
 # Bigquery integration tests
-[testenv:integration_bigquery_1.3.0]
-changedir = integration_test_project
-deps = dbt-bigquery~=1.3.0
-commands =
-    dbt deps
-    dbt build --target bigquery --vars '"my_var": "my value"'
-
-[testenv:integration_bigquery_1.4.0]
+[testenv:integration_bigquery]
 changedir = integration_test_project
 deps = dbt-bigquery~=1.4.0
 commands =
     dbt deps
     dbt build --target bigquery --vars '"my_var": "my value"'
 
-[testenv:integration_bigquery_1.5.0]
+[testenv:integration_bigquery_1_3_0]
+changedir = integration_test_project
+deps = dbt-bigquery~=1.3.0
+commands =
+    dbt deps
+    dbt build --target bigquery --vars '"my_var": "my value"'
+
+[testenv:integration_bigquery_1_4_0]
+changedir = integration_test_project
+deps = dbt-bigquery~=1.4.0
+commands =
+    dbt deps
+    dbt build --target bigquery --vars '"my_var": "my value"'
+
+[testenv:integration_bigquery_1_5_0]
 changedir = integration_test_project
 deps = dbt-bigquery~=1.5.0
 commands =
@@ -186,7 +208,7 @@ commands =
 # Spark integration test (disabled)
 [testenv:integration_spark]
 changedir = integration_test_project
-deps = dbt-spark[ODBC]~=1.3.0
+deps = dbt-spark[ODBC]~=1.4.0
 commands =
     dbt deps
     dbt build --exclude snapshot --target spark


### PR DESCRIPTION
## Overview

This tries a different approach to naming versions and removes the period for an underscore. It also changes the last release version command to not include the version number (will not be relevant after next release). Finally it adds a `--debug` flag,

## Update type - breaking / non-breaking

<!-- What type of update is this? -->
- [x] Minor bug fix
- [ ] Documentation improvements
- [ ] Quality of Life improvements
- [ ] New features (non-breaking change)
- [ ] New features (breaking change)
- [ ] Other (non-breaking change)
- [ ] Other (breaking change)

## What does this solve?

Failing CI issues

## Outstanding questions

N/A

## What databases have you tested with?

<!-- You don't need to have tested with them all, but this helps us know which you have tried already -->
- [ ] Snowflake
- [ ] Google BigQuery
- [ ] Databricks
- [ ] Spark
- [x] N/A
