### PR TITLE
[Fix] Move dbt deps and clean commands to different lines

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -122,7 +122,8 @@ commands = dbt docs generate --profiles-dir integration_test_project
 changedir = integration_test_project
 deps = dbt-snowflake~=1.4.0
 commands =
-    dbt clean && dbt deps
+    dbt clean
+    dbt deps
     dbt --debug build --target snowflake
 
 
@@ -130,21 +131,24 @@ commands =
 changedir = integration_test_project
 deps = dbt-snowflake~=1.3.0
 commands =
-    dbt clean && dbt deps
+    dbt clean
+    dbt deps
     dbt --debug build --target snowflake
 
 [testenv:integration_snowflake_1_4_0]
 changedir = integration_test_project
 deps = dbt-snowflake~=1.4.0
 commands =
-    dbt clean && dbt deps
+    dbt clean
+    dbt deps
     dbt --debug build --target snowflake
 
 [testenv:integration_snowflake_1_5_0]
 changedir = integration_test_project
 deps = dbt-snowflake~=1.5.0
 commands =
-    dbt clean && dbt deps
+    dbt clean
+    dbt deps
     dbt --debug build --target snowflake
 
 # Databricks integration tests
@@ -152,28 +156,32 @@ commands =
 changedir = integration_test_project
 deps = dbt-databricks~=1.4.0
 commands =
-    dbt clean && dbt deps
+    dbt clean
+    dbt deps
     dbt --debug build --target databricks
 
 [testenv:integration_databricks_1_3_0]
 changedir = integration_test_project
 deps = dbt-databricks~=1.3.0
 commands =
-    dbt clean && dbt deps
+    dbt clean
+    dbt deps
     dbt --debug build --target databricks
 
 [testenv:integration_databricks_1_4_0]
 changedir = integration_test_project
 deps = dbt-databricks~=1.4.0
 commands =
-    dbt clean && dbt deps
+    dbt clean
+    dbt deps
     dbt --debug build --target databricks
 
 [testenv:integration_databricks_1_5_0]
 changedir = integration_test_project
 deps = dbt-databricks~=1.5.0
 commands =
-    dbt clean && dbt deps
+    dbt clean
+    dbt deps
     dbt --debug build --target databricks
 
 # Bigquery integration tests
@@ -181,28 +189,32 @@ commands =
 changedir = integration_test_project
 deps = dbt-bigquery~=1.4.0
 commands =
-    dbt clean && dbt deps
+    dbt clean
+    dbt deps
     dbt --debug build --target bigquery --vars '"my_var": "my value"'
 
 [testenv:integration_bigquery_1_3_0]
 changedir = integration_test_project
 deps = dbt-bigquery~=1.3.0
 commands =
-    dbt clean && dbt deps
+    dbt clean
+    dbt deps
     dbt --debug build --target bigquery --vars '"my_var": "my value"'
 
 [testenv:integration_bigquery_1_4_0]
 changedir = integration_test_project
 deps = dbt-bigquery~=1.4.0
 commands =
-    dbt clean && dbt deps
+    dbt clean
+    dbt deps
     dbt --debug build --target bigquery --vars '"my_var": "my value"'
 
 [testenv:integration_bigquery_1_5_0]
 changedir = integration_test_project
 deps = dbt-bigquery~=1.5.0
 commands =
-    dbt clean && dbt deps
+    dbt clean
+    dbt deps
     dbt --debug build --target bigquery --vars '"my_var": "my value"'
 
 # Spark integration test (disabled)
@@ -210,6 +222,7 @@ commands =
 changedir = integration_test_project
 deps = dbt-spark[ODBC]~=1.4.0
 commands =
-    dbt clean && dbt deps
+    dbt clean
+    dbt deps
     dbt --debug build --exclude snapshot --target spark
 


### PR DESCRIPTION
## Overview

- `&&` does not work on Github runner
- This PR separates the `clean` and `deps` onto different lines in the Tox file 

## Update type - breaking / non-breaking

<!-- What type of update is this? -->
- [X] Minor bug fix
- [ ] Documentation improvements
- [ ] Quality of Life improvements
- [ ] New features (non-breaking change)
- [ ] New features (breaking change)
- [ ] Other (non-breaking change)
- [ ] Other (breaking change)

## What does this solve?

<!-- Include any links to relevant open issues -->

## Outstanding questions

<!-- Include any details here of issues you found along the way, or things that still require attention -->

## What databases have you tested with?

<!-- You don't need to have tested with them all, but this helps us know which you have tried already -->
- [X] Snowflake
- [ ] Google BigQuery
- [X] Databricks
- [ ] Spark
- [ ] N/A
