### PR TITLE
[Fix] Change integration_databricks tox to use dbt 1.3.0

### DIFF
--- a/integration_test_project/profiles.yml
+++ b/integration_test_project/profiles.yml
@@ -24,7 +24,7 @@ dbt_artifacts:
       host: "{{ env_var('DBT_ENV_SECRET_DATABRICKS_HOST') }}"
       http_path: "{{ env_var('DBT_ENV_SECRET_DATABRICKS_HTTP_PATH') }}"
       token: "{{ env_var('DBT_ENV_SECRET_DATABRICKS_TOKEN') }}"
-      threads: 8
+      threads: 5
     spark:
       type: spark
       method: odbc

--- a/tox.ini
+++ b/tox.ini
@@ -154,7 +154,7 @@ commands =
 # Databricks integration tests
 [testenv:integration_databricks]
 changedir = integration_test_project
-deps = dbt-databricks~=1.4.0
+deps = dbt-databricks~=1.3.0
 commands =
     dbt clean
     dbt deps

--- a/tox.ini
+++ b/tox.ini
@@ -154,7 +154,7 @@ commands =
 # Databricks integration tests
 [testenv:integration_databricks]
 changedir = integration_test_project
-deps = dbt-databricks~=1.3.0
+deps = dbt-databricks~=1.4.0
 commands =
     dbt clean
     dbt deps


### PR DESCRIPTION
## Overview
- The last time the DBX integration tests worked it was set to dbt ~1.3.0
- I think 1.4.0 contains changes to the connection that 1.3.0 does not and I want to see if it is this

## Update type - breaking / non-breaking

<!-- What type of update is this? -->
- [X] Minor bug fix
- [ ] Documentation improvements
- [ ] Quality of Life improvements
- [ ] New features (non-breaking change)
- [ ] New features (breaking change)
- [ ] Other (non-breaking change)
- [ ] Other (breaking change)

## What does this solve?

<!-- Include any links to relevant open issues -->

## Outstanding questions

<!-- Include any details here of issues you found along the way, or things that still require attention -->

## What databases have you tested with?

<!-- You don't need to have tested with them all, but this helps us know which you have tried already -->
- [ ] Snowflake
- [ ] Google BigQuery
- [X] Databricks
- [ ] Spark
- [ ] N/A
