### PR TITLE
[Refactor] Reduce databricks threads to 5 from 8

### DIFF
--- a/integration_test_project/profiles.yml
+++ b/integration_test_project/profiles.yml
@@ -24,7 +24,7 @@ dbt_artifacts:
       host: "{{ env_var('DBT_ENV_SECRET_DATABRICKS_HOST') }}"
       http_path: "{{ env_var('DBT_ENV_SECRET_DATABRICKS_HTTP_PATH') }}"
       token: "{{ env_var('DBT_ENV_SECRET_DATABRICKS_TOKEN') }}"
-      threads: 5
+      threads: 2
     spark:
       type: spark
       method: odbc

--- a/integration_test_project/profiles.yml
+++ b/integration_test_project/profiles.yml
@@ -24,7 +24,7 @@ dbt_artifacts:
       host: "{{ env_var('DBT_ENV_SECRET_DATABRICKS_HOST') }}"
       http_path: "{{ env_var('DBT_ENV_SECRET_DATABRICKS_HTTP_PATH') }}"
       token: "{{ env_var('DBT_ENV_SECRET_DATABRICKS_TOKEN') }}"
-      threads: 8
+      threads: 5
     spark:
       type: spark
       method: odbc


### PR DESCRIPTION
## Overview

- Reduces the number of DBX threads used in CI from 8 to 5

## Update type - breaking / non-breaking

<!-- What type of update is this? -->
- [X] Minor bug fix
- [ ] Documentation improvements
- [ ] Quality of Life improvements
- [ ] New features (non-breaking change)
- [ ] New features (breaking change)
- [] Other (non-breaking change)
- [ ] Other (breaking change)

## What does this solve?

<!-- Include any links to relevant open issues -->

## Outstanding questions

<!-- Include any details here of issues you found along the way, or things that still require attention -->

## What databases have you tested with?

<!-- You don't need to have tested with them all, but this helps us know which you have tried already -->
- [ ] Snowflake
- [ ] Google BigQuery
- [X] Databricks
- [ ] Spark
- [ ] N/A
