### PR TITLE
Remove databricks CI checks

### DIFF
--- a/.github/workflows/ci_test_package.yml
+++ b/.github/workflows/ci_test_package.yml
@@ -138,26 +138,26 @@ jobs:
         run: tox -e integration_${{ matrix.warehouse }}_${{ matrix.version }}
 
   # Databricks doesn't like the matrix strategy, so moving back to the old integration testing without versioning
-  integration-databricks:
-    runs-on: ubuntu-latest
-    environment:
-      name: Approve Integration Tests
+  # integration-databricks:
+  #   runs-on: ubuntu-latest
+  #   environment:
+  #     name: Approve Integration Tests
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }} # Check out the code of the PR
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
+  #       with:
+  #         ref: ${{ github.event.pull_request.head.sha }} # Check out the code of the PR
 
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.8.x'
-          architecture: 'x64'
+  #     - uses: actions/setup-python@v4
+  #       with:
+  #         python-version: '3.8.x'
+  #         architecture: 'x64'
 
-      - name: Install tox
-        run: python3 -m pip install tox
+  #     - name: Install tox
+  #       run: python3 -m pip install tox
 
-      - name: Run Databricks Tests
-        env:
-          DBT_VERSION: ''
-        run: tox -e integration_databricks
+  #     - name: Run Databricks Tests
+  #       env:
+  #         DBT_VERSION: ''
+  #       run: tox -e integration_databricks

--- a/.github/workflows/main_test_package.yml
+++ b/.github/workflows/main_test_package.yml
@@ -66,20 +66,20 @@ jobs:
         run: tox -e integration_${{ matrix.warehouse }}_${{ matrix.version }}
 
   # Databricks doesn't like the matrix strategy, so moving back to the old integration testing without versioning
-  integration-databricks:
-    runs-on: ubuntu-latest
+  # integration-databricks:
+  #   runs-on: ubuntu-latest
 
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
+  #   steps:
+  #     - name: Checkout
+  #       uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v4
-        with:
-          python-version: '3.8.x'
-          architecture: 'x64'
+  #     - uses: actions/setup-python@v4
+  #       with:
+  #         python-version: '3.8.x'
+  #         architecture: 'x64'
 
-      - name: Install tox
-        run: python3 -m pip install tox
+  #     - name: Install tox
+  #       run: python3 -m pip install tox
 
-      - name: Run Databricks Tests
-        run: tox -e integration_databricks
+  #     - name: Run Databricks Tests
+  #       run: tox -e integration_databricks


### PR DESCRIPTION
## Overview

There are [issues](https://github.com/databricks/dbt-databricks/issues/352) with running dbt-databricks via GHA, which means that the CI checks are continuously failing and we've been unable to get a release out. Therefore, this removes those checks (temporarily), and instead they will need to be run locally prior to any dbx changes.

Tests to run locally: 

```sh
tox -e integration_databricks_1_3_0
tox -e integration_databricks_1_4_0
tox -e integration_databricks_1_5_0
```

## Update type - breaking / non-breaking

<!-- What type of update is this? -->
- [x] Minor bug fix
- [ ] Documentation improvements
- [ ] Quality of Life improvements
- [ ] New features (non-breaking change)
- [ ] New features (breaking change)
- [ ] Other (non-breaking change)
- [ ] Other (breaking change)

## What does this solve?

- Failing CI checks

## Outstanding questions

N/A

## What databases have you tested with?

<!-- You don't need to have tested with them all, but this helps us know which you have tried already -->
- [ ] Snowflake
- [ ] Google BigQuery
- [x] Databricks
- [ ] Spark
- [ ] N/A
