### PR TITLE
[Fix] Add batching when uploading models

### DIFF
--- a/macros/upload_models.sql
+++ b/macros/upload_models.sql
@@ -1,8 +1,4 @@
-{% macro upload_models(graph) -%}
-    {% set models = [] %}
-    {% for node in graph.nodes.values() | selectattr("resource_type", "equalto", "model") %}
-        {% do models.append(node) %}
-    {% endfor %}
+{% macro upload_models(models) -%}
     {{ return(adapter.dispatch('get_models_dml_sql', 'dbt_artifacts')(models)) }}
 {%- endmacro %}
 

--- a/macros/upload_results.sql
+++ b/macros/upload_results.sql
@@ -112,7 +112,7 @@
         {% for node in graph.nodes.values() | selectattr("resource_type", "equalto", "model") %}
             {% do models_set.append(node) %}
         {% endfor %}
-        {% set upload_limit = 50 if target.type == 'bigquery' else 5000 %}
+        {% set upload_limit = 50 if target.type == 'bigquery' else 100 %}
         {% for i in range(0, models_set | length, upload_limit) -%}
             {% set content_models = dbt_artifacts.upload_models(models_set[i: i + upload_limit]) %}
             {{ dbt_artifacts.insert_into_metadata_table(


### PR DESCRIPTION
## Overview

- In release `2.4.0` was added the `all_results` JSON object to `upload_models.sql`
- This results in large queries that are too big for BigQuery which we saw for tests.
- This PR uses the exact same logic for tests but in models.

## Update type - breaking / non-breaking

<!-- What type of update is this? -->
- [ ] Minor bug fix
- [ ] Documentation improvements
- [ ] Quality of Life improvements
- [X] New features (non-breaking change)
- [ ] New features (breaking change)
- [ ] Other (non-breaking change)
- [ ] Other (breaking change)

## What does this solve?

#343 

## Outstanding questions

- Need confirmation on what the correct batch size should be 

## What databases have you tested with?

<!-- You don't need to have tested with them all, but this helps us know which you have tried already -->
- [ ] Snowflake
- [X] Google BigQuery
- [ ] Databricks
- [ ] Spark
- [ ] N/A
