### PR TITLE
[Fix] Add wide_number_mode to BigQuery all results columns

### DIFF
--- a/macros/upload_exposures.sql
+++ b/macros/upload_exposures.sql
@@ -70,7 +70,7 @@
                     '{{ exposure.package_name }}', {# package_name #}
                     {{ tojson(exposure.depends_on.nodes) }}, {# depends_on_nodes #}
                     {{ tojson(exposure.tags) }}, {# tags #}
-                    parse_json('{{ tojson(exposure) | replace("\\", "\\\\") | replace("'", "\\'") | replace('"', '\\"') }}') {# all_results #}
+                    parse_json('{{ tojson(exposure) | replace("\\", "\\\\") | replace("'", "\\'") | replace('"', '\\"') }}', wide_number_mode=>'round') {# all_results #}
                 )
                 {%- if not loop.last %},{%- endif %}
             {%- endfor %}

--- a/macros/upload_models.sql
+++ b/macros/upload_models.sql
@@ -73,7 +73,7 @@
                     {{ tojson(model.tags) }}, {# tags #}
                     parse_json('''{{ tojson(model.config.meta) }}'''), {# meta #}
                     '{{ model.alias }}', {# alias #}
-                    parse_json('{{ tojson(model) | replace("\\", "\\\\") | replace("'","\\'") | replace('"', '\\"') }}') {# all_results #}
+                    parse_json('{{ tojson(model) | replace("\\", "\\\\") | replace("'","\\'") | replace('"', '\\"') }}', wide_number_mode=>'round') {# all_results #}
                 )
                 {%- if not loop.last %},{%- endif %}
             {%- endfor %}

--- a/macros/upload_seeds.sql
+++ b/macros/upload_seeds.sql
@@ -64,7 +64,7 @@
                     '{{ seed.checksum.checksum }}', {# checksum #}
                     parse_json('''{{ tojson(seed.config.meta) }}'''), {# meta #}
                     '{{ seed.alias }}', {# alias #}
-                    parse_json('{{ tojson(seed) | replace("\\", "\\\\") | replace("'","\\'") | replace('"', '\\"') }}') {# all_results #}
+                    parse_json('{{ tojson(seed) | replace("\\", "\\\\") | replace("'","\\'") | replace('"', '\\"') }}', wide_number_mode=>'round') {# all_results #}
                 )
                 {%- if not loop.last %},{%- endif %}
             {%- endfor %}

--- a/macros/upload_snapshots.sql
+++ b/macros/upload_snapshots.sql
@@ -71,7 +71,7 @@
                     '{{ snapshot.config.strategy }}', {# strategy #}
                     parse_json('''{{ tojson(snapshot.config.meta) }}'''), {# meta #}
                     '{{ snapshot.alias }}', {# alias #}
-                    parse_json('{{ tojson(snapshot) | replace("\\", "\\\\") | replace("'","\\'") | replace('"', '\\"') }}') {# all_results #}
+                    parse_json('{{ tojson(snapshot) | replace("\\", "\\\\") | replace("'","\\'") | replace('"', '\\"') }}', wide_number_mode=>'round') {# all_results #}
                 )
                 {%- if not loop.last %},{%- endif %}
             {%- endfor %}


### PR DESCRIPTION
## Overview

- In Release `2.4.0` we added the `all_results` object to models.
- In some instances this contains a number that cannot be parsed to a string and results in the following error:

```
13:04:01  on-run-end failed, error:
13:04:01   Invalid input: Input number: 1685019801.1016695 cannot round-trip through string representation; error in PARSE_JSON expression
```

- [The BQ docs show the solution in the examples under parse_json](https://cloud.google.com/bigquery/docs/reference/standard-sql/json_functions#parse_json)
- This PR adds it to the `all_results` columns where it wasn't set previously
- I've opted to not put it on all objects as I believe at the moment this issue will only appear in the all_results column based on the objects that are being used

## Update type - breaking / non-breaking

<!-- What type of update is this? -->
- [X] Minor bug fix
- [ ] Documentation improvements
- [ ] Quality of Life improvements
- [ ] New features (non-breaking change)
- [ ] New features (breaking change)
- [ ] Other (non-breaking change)
- [ ] Other (breaking change)

## What does this solve?

<!-- Include any links to relevant open issues -->

## Outstanding questions

<!-- Include any details here of issues you found along the way, or things that still require attention -->

## What databases have you tested with?

<!-- You don't need to have tested with them all, but this helps us know which you have tried already -->
- [ ] Snowflake
- [X] Google BigQuery
- [ ] Databricks
- [ ] Spark
- [ ] N/A
