### PR TITLE
[Fix] Remove raw_code from all_results column in models

### DIFF
--- a/macros/upload_models.sql
+++ b/macros/upload_models.sql
@@ -24,6 +24,7 @@
             {{ adapter.dispatch('parse_json', 'dbt_artifacts')(adapter.dispatch('column_identifier', 'dbt_artifacts')(15)) }}
         from values
         {% for model in models -%}
+                {% do model.pop('raw_code', None) %}
             (
                 '{{ invocation_id }}', {# command_invocation_id #}
                 '{{ model.unique_id }}', {# node_id #}
@@ -54,6 +55,7 @@
     {% if models != [] %}
         {% set model_values %}
             {% for model in models -%}
+                {% do model.pop('raw_code', None) %}
                 (
                     '{{ invocation_id }}', {# command_invocation_id #}
                     '{{ model.unique_id }}', {# node_id #}


### PR DESCRIPTION
## Overview

- In a recent release we added an `all_results` column to models which contains all the elements from the manifest for each model.
- This caused issues with some DWHs because the records started to exceed limits.
- As a workaround we have introduced batching of records in some previous PRs.
- However, I think the raw sql is a big part of what is making the records large in the first place and doesn't need to be stored.
- In a future commit it might be worth revoking more elements of this field / the field entirely and moving back to parsing out elements and adding new columns.


## Update type - breaking / non-breaking

<!-- What type of update is this? -->
- [ ] Minor bug fix
- [ ] Documentation improvements
- [ ] Quality of Life improvements
- [ ] New features (non-breaking change)
- [ ] New features (breaking change)
- [X] Other (non-breaking change)
- [ ] Other (breaking change)

## What does this solve?

<!-- Include any links to relevant open issues -->

## Outstanding questions

<!-- Include any details here of issues you found along the way, or things that still require attention -->

## What databases have you tested with?

<!-- You don't need to have tested with them all, but this helps us know which you have tried already -->
- [ ] Snowflake
- [x] Google BigQuery
- [x] Databricks
- [ ] Spark
- [ ] N/A
