### PR TITLE
fix: Escape single quotes in invocation_args

### DIFF
--- a/macros/upload_invocations.sql
+++ b/macros/upload_invocations.sql
@@ -83,7 +83,7 @@
             null, {# dbt_vars #}
         {% endif %}
 
-        '{{ tojson(invocation_args_dict) | replace('\\', '\\\\') }}', {# invocation_args #}
+        '{{ tojson(invocation_args_dict) | replace('\\', '\\\\') | replace("'", "\\'") }}', {# invocation_args #}
 
         {% set metadata_env = {} %}
         {% for key, value in dbt_metadata_envs.items() %}
@@ -146,7 +146,7 @@
             {% endif %}
         {% endif %}
 
-        safe.parse_json('''{{ tojson(invocation_args_dict) }}'''), {# invocation_args #}
+        safe.parse_json('''{{ tojson(invocation_args_dict) | replace("'", "\\'") }}'''), {# invocation_args #}
 
         {% set metadata_env = {} %}
         {% for key, value in dbt_metadata_envs.items() %}


### PR DESCRIPTION
## Overview

Related to #316, this change fixes another occurrence, this time for `invocations.invocation_args`. As DBT variables can contain single quotes, they must be escaped.

## Update type - breaking / non-breaking

- [x] Minor bug fix
- [ ] Documentation improvements
- [ ] Quality of Life improvements
- [ ] New features (non-breaking change)
- [ ] New features (breaking change)
- [ ] Other (non-breaking change)
- [ ] Other (breaking change)

## What does this solve?

Another scenario for #316.

## What databases have you tested with?

- [x] Snowflake
- [ ] Google BigQuery
- [ ] Databricks
- [ ] Spark
- [ ] N/A
