### PR TITLE
Add wide_number_mode to remaining BigQuery upload macros

### DIFF
--- a/macros/upload_test_executions.sql
+++ b/macros/upload_test_executions.sql
@@ -120,7 +120,7 @@
                 null, {# rows_affected not available in Databricks #}
                 {{ 'null' if test.failures is none else test.failures }}, {# failures #}
                 '{{ test.message | replace("\\", "\\\\") | replace("'", "\\'") | replace('"', '\\"') }}', {# message #}
-                parse_json('{{ tojson(test.adapter_response) | replace("\\", "\\\\") | replace("'", "\\'") | replace('"', '\\"') }}') {# adapter_response #}
+                parse_json('{{ tojson(test.adapter_response) | replace("\\", "\\\\") | replace("'", "\\'") | replace('"', '\\"') }}', wide_number_mode=>'round') {# adapter_response #}
 
             )
             {%- if not loop.last %},{%- endif %}

--- a/macros/upload_tests.sql
+++ b/macros/upload_tests.sql
@@ -51,7 +51,7 @@
                     '{{ test.package_name }}', {# package_name #}
                     '{{ test.original_file_path | replace('\\', '\\\\') }}', {# test_path #}
                     {{ tojson(test.tags) }}, {# tags #}
-                    parse_json('{{ tojson(test) | replace("\\", "\\\\") | replace("'","\\'") | replace('"', '\\"') }}') {# all_fields #}
+                    parse_json('{{ tojson(test) | replace("\\", "\\\\") | replace("'","\\'") | replace('"', '\\"') }}', wide_number_mode=>'round') {# all_fields #}
                 )
                 {%- if not loop.last %},{%- endif %}
             {%- endfor %}


### PR DESCRIPTION
## Overview

It extends the fix to the test macros for the error mentioned in https://github.com/brooklyn-data/dbt_artifacts/pull/345. 


## Update type - breaking / non-breaking

<!-- What type of update is this? -->
- [x] Minor bug fix
- [ ] Documentation improvements
- [ ] Quality of Life improvements
- [ ] New features (non-breaking change)
- [ ] New features (breaking change)
- [ ] Other (non-breaking change)
- [ ] Other (breaking change)

## What does this solve?

<!-- Include any links to relevant open issues -->

## Outstanding questions

<!-- Include any details here of issues you found along the way, or things that still require attention -->

## What databases have you tested with?

<!-- You don't need to have tested with them all, but this helps us know which you have tried already -->
- [ ] Snowflake
- [x] Google BigQuery
- [ ] Databricks
- [ ] Spark
- [ ] N/A
