### PR TITLE
parse_json({{ field }}, wide_number_mode=>'round') was added for the …

### DIFF
--- a/macros/parse_json.sql
+++ b/macros/parse_json.sql
@@ -11,6 +11,6 @@
 {%- endmacro %}
 
 {% macro bigquery__parse_json(field) -%}
-    parse_json({{ field }})
+    parse_json({{ field }}, wide_number_mode=>'round')
 {%- endmacro %}
 

--- a/macros/upload_exposures.sql
+++ b/macros/upload_exposures.sql
@@ -70,7 +70,7 @@
                     '{{ exposure.package_name }}', {# package_name #}
                     {{ tojson(exposure.depends_on.nodes) }}, {# depends_on_nodes #}
                     {{ tojson(exposure.tags) }}, {# tags #}
-                    parse_json('{{ tojson(exposure) | replace("\\", "\\\\") | replace("'", "\\'") | replace('"', '\\"') }}', wide_number_mode=>'round') {# all_results #}
+                    parse_json('{{ tojson(exposure) | replace("\\", "\\\\") | replace("'", "\\'") | replace('"', '\\"') }}') {# all_results #}
                 )
                 {%- if not loop.last %},{%- endif %}
             {%- endfor %}

--- a/macros/upload_models.sql
+++ b/macros/upload_models.sql
@@ -71,7 +71,7 @@
                     {{ tojson(model.tags) }}, {# tags #}
                     parse_json('''{{ tojson(model.config.meta) }}'''), {# meta #}
                     '{{ model.alias }}', {# alias #}
-                    parse_json('{{ tojson(model) | replace("\\", "\\\\") | replace("'","\\'") | replace('"', '\\"') }}', wide_number_mode=>'round') {# all_results #}
+                    parse_json('{{ tojson(model) | replace("\\", "\\\\") | replace("'","\\'") | replace('"', '\\"') }}') {# all_results #}
                 )
                 {%- if not loop.last %},{%- endif %}
             {%- endfor %}

--- a/macros/upload_seeds.sql
+++ b/macros/upload_seeds.sql
@@ -64,7 +64,7 @@
                     '{{ seed.checksum.checksum }}', {# checksum #}
                     parse_json('''{{ tojson(seed.config.meta) }}'''), {# meta #}
                     '{{ seed.alias }}', {# alias #}
-                    parse_json('{{ tojson(seed) | replace("\\", "\\\\") | replace("'","\\'") | replace('"', '\\"') }}', wide_number_mode=>'round') {# all_results #}
+                    parse_json('{{ tojson(seed) | replace("\\", "\\\\") | replace("'","\\'") | replace('"', '\\"') }}') {# all_results #}
                 )
                 {%- if not loop.last %},{%- endif %}
             {%- endfor %}

--- a/macros/upload_snapshots.sql
+++ b/macros/upload_snapshots.sql
@@ -71,7 +71,7 @@
                     '{{ snapshot.config.strategy }}', {# strategy #}
                     parse_json('''{{ tojson(snapshot.config.meta) }}'''), {# meta #}
                     '{{ snapshot.alias }}', {# alias #}
-                    parse_json('{{ tojson(snapshot) | replace("\\", "\\\\") | replace("'","\\'") | replace('"', '\\"') }}', wide_number_mode=>'round') {# all_results #}
+                    parse_json('{{ tojson(snapshot) | replace("\\", "\\\\") | replace("'","\\'") | replace('"', '\\"') }}') {# all_results #}
                 )
                 {%- if not loop.last %},{%- endif %}
             {%- endfor %}

--- a/macros/upload_sources.sql
+++ b/macros/upload_sources.sql
@@ -60,7 +60,7 @@
                     '{{ source.identifier }}', {# identifier #}
                     '{{ source.loaded_at_field | replace("'","\\'") }}', {# loaded_at_field #}
                     parse_json('{{ tojson(source.freshness) | replace("'","\\'") }}'),  {# freshness #}
-                    parse_json('{{ tojson(source) | replace("\\", "\\\\") | replace("'", "\\'") | replace('"', '\\"') }}', wide_number_mode=>'round') {# all_results #}
+                    parse_json('{{ tojson(source) | replace("\\", "\\\\") | replace("'", "\\'") | replace('"', '\\"') }}') {# all_results #}
                 )
                 {%- if not loop.last %},{%- endif %}
             {%- endfor %}


### PR DESCRIPTION
…bigquery


## Overview

<!-- In 1-2 sentences, provide an overview of what this PR does -->

## Update type - breaking / non-breaking

<!-- What type of update is this? -->
- [x] Minor bug fix
- [ ] Documentation improvements
- [ ] Quality of Life improvements
- [ ] New features (non-breaking change)
- [ ] New features (breaking change)
- [ ] Other (non-breaking change)
- [ ] Other (breaking change)

## What does this solve?

<!-- Include any links to relevant open issues -->
```bash
06:50:58  Running 1 on-run-end hook
06:50:58  Uploading model executions
06:51:02  Uploading seed executions
06:51:02  Uploading snapshot executions
06:51:02  Uploading test executions
06:51:02  Uploading exposures
06:51:05  Uploading tests
06:52:15  BigQuery adapter: https://console.cloud.google.com&page=queryresults
06:52:15  Database error while running on-run-end
06:52:15  
06:52:15  Finished running 11 incremental models, 23 view models in 0 hours 1 minutes and 58.26 seconds (118.26s).
06:52:16  
06:52:16  Completed with 1 error and 0 warnings:
06:52:16  
06:52:16  on-run-end failed, error:
06:52:16   Invalid input: Input number: 1686725407.683936 cannot round-trip through string representation; error in PARSE_JSON expression
06:52:16  
06:52:16  Done. PASS=34 WARN=0 ERROR=1 SKIP=0 TOTAL=35
```
## Outstanding questions

<!-- Include any details here of issues you found along the way, or things that still require attention -->

## What databases have you tested with?

<!-- You don't need to have tested with them all, but this helps us know which you have tried already -->
- [ ] Snowflake
- [x] Google BigQuery
- [ ] Databricks
- [ ] Spark
- [ ] N/A
