### PR TITLE
Escape newline for BQ execution messages

### DIFF
--- a/macros/upload_model_executions.sql
+++ b/macros/upload_model_executions.sql
@@ -130,7 +130,7 @@
             '{{ model.node.schema }}', {# schema #}
             '{{ model.node.name }}', {# name #}
             '{{ model.node.alias }}', {# alias #}
-            '{{ model.message | replace("\\", "\\\\") | replace("'", "\\'") | replace('"', '\\"') }}', {# message #}
+            '{{ model.message | replace("\\", "\\\\") | replace("'", "\\'") | replace('"', '\\"') | | replace("\n", "\\n") }}', {# message #}
             parse_json('{{ tojson(model.adapter_response) | replace("\\", "\\\\") | replace("'", "\\'") | replace('"', '\\"') }}') {# adapter_response #}
             )
             {%- if not loop.last %},{%- endif %}

--- a/macros/upload_model_executions.sql
+++ b/macros/upload_model_executions.sql
@@ -130,7 +130,7 @@
             '{{ model.node.schema }}', {# schema #}
             '{{ model.node.name }}', {# name #}
             '{{ model.node.alias }}', {# alias #}
-            '{{ model.message | replace("\\", "\\\\") | replace("'", "\\'") | replace('"', '\\"') | | replace("\n", "\\n") }}', {# message #}
+            '{{ model.message | replace("\\", "\\\\") | replace("'", "\\'") | replace('"', '\\"') | replace("\n", "\\n") }}', {# message #}
             parse_json('{{ tojson(model.adapter_response) | replace("\\", "\\\\") | replace("'", "\\'") | replace('"', '\\"') }}') {# adapter_response #}
             )
             {%- if not loop.last %},{%- endif %}

--- a/macros/upload_seed_executions.sql
+++ b/macros/upload_seed_executions.sql
@@ -128,7 +128,7 @@
                 '{{ model.node.schema }}', {# schema #}
                 '{{ model.node.name }}', {# name #}
                 '{{ model.node.alias }}', {# alias #}
-                '{{ model.message | replace("\\", "\\\\") | replace("'", "\\'") | replace('"', '\\"') }}', {# message #}
+                '{{ model.message | replace("\\", "\\\\") | replace("'", "\\'") | replace('"', '\\"') | | replace("\n", "\\n") }}', {# message #}
                 parse_json('{{ tojson(model.adapter_response) | replace("\\", "\\\\") | replace("'", "\\'") | replace('"', '\\"') }}') {# adapter_response #}
             )
             {%- if not loop.last %},{%- endif %}

--- a/macros/upload_seed_executions.sql
+++ b/macros/upload_seed_executions.sql
@@ -128,7 +128,7 @@
                 '{{ model.node.schema }}', {# schema #}
                 '{{ model.node.name }}', {# name #}
                 '{{ model.node.alias }}', {# alias #}
-                '{{ model.message | replace("\\", "\\\\") | replace("'", "\\'") | replace('"', '\\"') | | replace("\n", "\\n") }}', {# message #}
+                '{{ model.message | replace("\\", "\\\\") | replace("'", "\\'") | replace('"', '\\"') | replace("\n", "\\n") }}', {# message #}
                 parse_json('{{ tojson(model.adapter_response) | replace("\\", "\\\\") | replace("'", "\\'") | replace('"', '\\"') }}') {# adapter_response #}
             )
             {%- if not loop.last %},{%- endif %}

--- a/macros/upload_snapshot_executions.sql
+++ b/macros/upload_snapshot_executions.sql
@@ -128,7 +128,7 @@
                 '{{ model.node.schema }}', {# schema #}
                 '{{ model.node.name }}', {# name #}
                 '{{ model.node.alias }}', {# alias #}
-                '{{ model.message | replace("\\", "\\\\") | replace("'", "\\'") | replace('"', '\\"') }}', {# message #}
+                '{{ model.message | replace("\\", "\\\\") | replace("'", "\\'") | replace('"', '\\"') | replace("\n", "\\n") }}', {# message #}
                 parse_json('{{ tojson(model.adapter_response) | replace("\\", "\\\\") | replace("'", "\\'") | replace('"', '\\"') }}') {# adapter_response #}
             )
             {%- if not loop.last %},{%- endif %}

--- a/macros/upload_test_executions.sql
+++ b/macros/upload_test_executions.sql
@@ -119,7 +119,7 @@
                 {{ test.execution_time }}, {# total_node_runtime #}
                 null, {# rows_affected not available in Databricks #}
                 {{ 'null' if test.failures is none else test.failures }}, {# failures #}
-                '{{ test.message | replace("\\", "\\\\") | replace("'", "\\'") | replace('"', '\\"') }}', {# message #}
+                '{{ test.message | replace("\\", "\\\\") | replace("'", "\\'") | replace('"', '\\"') | replace("\n", "\\n") }}', {# message #}
                 parse_json('{{ tojson(test.adapter_response) | replace("\\", "\\\\") | replace("'", "\\'") | replace('"', '\\"') }}') {# adapter_response #}
 
             )


### PR DESCRIPTION
## Overview
Adding escape newline for BigQuery model/seed/snapshot/test executions
When there's an execution failure, BigQuery will produce multiline error messages, which will break dbt_artifacts, causing records not getting uploaded correctly. 

## Update type - breaking / non-breaking

<!-- What type of update is this? -->
- [x] Minor bug fix
- [ ] Documentation improvements
- [ ] Quality of Life improvements
- [ ] New features (non-breaking change)
- [ ] New features (breaking change)
- [ ] Other (non-breaking change)
- [ ] Other (breaking change)

## What does this solve?

#361 

## Outstanding questions

<!-- Include any details here of issues you found along the way, or things that still require attention -->

## What databases have you tested with?

<!-- You don't need to have tested with them all, but this helps us know which you have tried already -->
- [ ] Snowflake
- [x] Google BigQuery
- [ ] Databricks
- [ ] Spark
- [ ] N/A
