### PR TITLE
Add config blocks for the "source" models

### DIFF
--- a/models/sources/exposures.sql
+++ b/models/sources/exposures.sql
@@ -1,3 +1,9 @@
+{{
+    config(
+        materialized='incremental',
+        on_schema_change='append_new_columns'
+    )
+}}
 /* Bigquery won't let us `where` without `from` so we use this workaround */
 with dummy_cte as (
     select 1 as foo

--- a/models/sources/invocations.sql
+++ b/models/sources/invocations.sql
@@ -1,3 +1,9 @@
+{{
+    config(
+        materialized='incremental',
+        on_schema_change='append_new_columns'
+    )
+}}
 /* Bigquery won't let us `where` without `from` so we use this workaround */
 with dummy_cte as (
     select 1 as foo

--- a/models/sources/model_executions.sql
+++ b/models/sources/model_executions.sql
@@ -1,3 +1,9 @@
+{{
+    config(
+        materialized='incremental',
+        on_schema_change='append_new_columns'
+    )
+}}
 /* Bigquery won't let us `where` without `from` so we use this workaround */
 with dummy_cte as (
     select 1 as foo

--- a/models/sources/models.sql
+++ b/models/sources/models.sql
@@ -1,3 +1,9 @@
+{{
+    config(
+        materialized='incremental',
+        on_schema_change='append_new_columns'
+    )
+}}
 /* Bigquery won't let us `where` without `from` so we use this workaround */
 with dummy_cte as (
     select 1 as foo

--- a/models/sources/seed_executions.sql
+++ b/models/sources/seed_executions.sql
@@ -1,3 +1,9 @@
+{{
+    config(
+        materialized='incremental',
+        on_schema_change='append_new_columns'
+    )
+}}
 /* Bigquery won't let us `where` without `from` so we use this workaround */
 with dummy_cte as (
     select 1 as foo

--- a/models/sources/seeds.sql
+++ b/models/sources/seeds.sql
@@ -1,3 +1,9 @@
+{{
+    config(
+        materialized='incremental',
+        on_schema_change='append_new_columns'
+    )
+}}
 /* Bigquery won't let us `where` without `from` so we use this workaround */
 with dummy_cte as (
     select 1 as foo

--- a/models/sources/snapshot_executions.sql
+++ b/models/sources/snapshot_executions.sql
@@ -1,3 +1,9 @@
+{{
+    config(
+        materialized='incremental',
+        on_schema_change='append_new_columns'
+    )
+}}
 /* Bigquery won't let us `where` without `from` so we use this workaround */
 with dummy_cte as (
     select 1 as foo

--- a/models/sources/snapshots.sql
+++ b/models/sources/snapshots.sql
@@ -1,3 +1,9 @@
+{{
+    config(
+        materialized='incremental',
+        on_schema_change='append_new_columns'
+    )
+}}
 /* Bigquery won't let us `where` without `from` so we use this workaround */
 with dummy_cte as (
     select 1 as foo

--- a/models/sources/sources.sql
+++ b/models/sources/sources.sql
@@ -1,3 +1,9 @@
+{{
+    config(
+        materialized='incremental',
+        on_schema_change='append_new_columns'
+    )
+}}
 /* Bigquery won't let us `where` without `from` so we use this workaround */
 with dummy_cte as (
     select 1 as foo

--- a/models/sources/test_executions.sql
+++ b/models/sources/test_executions.sql
@@ -1,3 +1,9 @@
+{{
+    config(
+        materialized='incremental',
+        on_schema_change='append_new_columns'
+    )
+}}
 /* Bigquery won't let us `where` without `from` so we use this workaround */
 with dummy_cte as (
     select 1 as foo

--- a/models/sources/tests.sql
+++ b/models/sources/tests.sql
@@ -1,3 +1,9 @@
+{{
+    config(
+        materialized='incremental',
+        on_schema_change='append_new_columns'
+    )
+}}
 /* Bigquery won't let us `where` without `from` so we use this workaround */
 with dummy_cte as (
     select 1 as foo


### PR DESCRIPTION
## Overview
Adds config blocks to the upstream "source" models according to the dbt project file.

## Update type - breaking / non-breaking

<!-- What type of update is this? -->
- [ ] Minor bug fix
- [ ] Documentation improvements
- [x] Quality of Life improvements
- [x] New features (non-breaking change)
- [ ] New features (breaking change)
- [ ] Other (non-breaking change)
- [ ] Other (breaking change)
- [ ] Release preparation

## What does this solve?
I've been working on standardizing model configs in my project and I set the default materialization to table in the `dbt_project.yml`. It appears to have overridden the materialization for these "source" models such that the subsequent runs had been doing a `CREATE OR REPLACE` and wiping out all of the data without my knowing. At least that is what I think happened. I copied the project config settings from the repo to include the `source` block like so:
```
  dbt_artifacts:
    +schema: dbt_artifacts
    staging:
      +schema: dbt_artifacts
    sources:
      +materialized: incremental
      +on_schema_change: append_new_columns
```
and I confirmed that my dbt runs now look like:
```
21:19:30  1 of 34 START sql incremental model dbt_artifacts.exposures .................... [RUN]                                                                                                     
21:19:30  2 of 34 START sql incremental model dbt_artifacts.invocations .................. [RUN]                                                                                                     
...
```
instead of what they used to look like:
```
[2023-10-02, 21:02:38 UTC] {dbt_hook.py:191} INFO - [0m21:02:38  1 of 34 START sql table model dbt_artifacts.exposures .......................... [RUN]
[2023-10-02, 21:02:38 UTC] {dbt_hook.py:191} INFO - [0m21:02:38  2 of 34 START sql table model dbt_artifacts.invocations ........................ [RUN]
```

## Outstanding questions
Is this actually the expected behavior of the dbt_project configs? I would have thought that because the materialization for the `source` block was set in the project config for this package that I wouldn't be able to override it like I did.

Is there anything lost by setting these as project configs? I don't feel strongly about this change I'm just throwing it out there that this would have saved me from losing all my data.

## What databases have you tested with?

<!-- You don't need to have tested with them all, but this helps us know which you have tried already -->
- [x] Snowflake
- [ ] Google BigQuery
- [ ] Databricks
- [ ] Spark
- [ ] N/A
