### PR TITLE
add redshift support

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,11 +78,17 @@ Tox will take care of installing the dependencies for each environment, so you d
     tox -e integration_snowflake # For the Snowflake tests
     tox -e integration_databricks # For the Databricks tests
     tox -e integration_bigquery # For the BigQuery tests
+    tox -e integration_redshift # For the Redshift testss
     ```
 
 The Spark tests require installing the [ODBC driver](https://www.databricks.com/spark/odbc-drivers-download). On a Mac,
 DBT_ENV_SPARK_DRIVER_PATH should be set to `/Library/simba/spark/lib/libsparkodbc_sbu.dylib`. Spark tests have not yet
 been added to the integration tests.
+
+The Redshift tests require your AWS credentials configured in the current environment (either as environment variables or in your credentials
+file - see [Configure the AWS cli](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html)).  They are currently configured with IAM
+authorisation, so your principal will require the redshift:getClusterCredentials permission to retrieve the password for the specified redshift
+database user.
 
 If you don't have access to a particular database type, this isn't a problem. Test on the one you do have, and let us know in the PR.
 

--- a/integration_test_project/example-env.sh
+++ b/integration_test_project/example-env.sh
@@ -16,6 +16,10 @@ export DBT_ENV_SECRET_DATABRICKS_TOKEN=
 export DBT_ENV_SECRET_GCP_PROJECT=
 export DBT_ENV_SPARK_DRIVER_PATH= # /Library/simba/spark/lib/libsparkodbc_sbu.dylib on a Mac
 export DBT_ENV_SPARK_ENDPOINT= # The endpoint ID from the Databricks HTTP path
+export DBT_ENV_SECRET_REDSHIFT_HOST=
+export DBT_ENV_SECRET_REDSHIFT_CLUSTER_ID=
+export DBT_ENV_SECRET_REDSHIFT_DB=
+export DBT_ENV_SECRET_REDSHIFT_USER=
 
 # dbt environment variables, change these
 export DBT_VERSION="1_5_0"

--- a/integration_test_project/profiles.yml
+++ b/integration_test_project/profiles.yml
@@ -52,3 +52,13 @@ dbt_artifacts:
       dbname: postgres
       schema: public
       threads: 8
+    redshift:
+      type: redshift
+      method: iam
+      threads: 8
+      host: "{{ env_var('DBT_ENV_SECRET_REDSHIFT_HOST') }}"
+      port: 5439
+      dbname: "{{ env_var('DBT_ENV_SECRET_REDSHIFT_DB') }}"
+      user: "{{ env_var('DBT_ENV_SECRET_REDSHIFT_USER') }}"
+      schema: dbt_artifacts_test_commit_{{ env_var('DBT_VERSION', '') }}_{{ env_var('GITHUB_SHA_OVERRIDE', '') if env_var('GITHUB_SHA_OVERRIDE', '') else env_var('GITHUB_SHA') }}
+      cluster_id: "{{ env_var('DBT_ENV_SECRET_REDSHIFT_CLUSTER_ID') }}"

--- a/macros/_macros.yml
+++ b/macros/_macros.yml
@@ -57,6 +57,10 @@ macros:
     description: |
       Dependent on the adapter type, returns the native type for storing JSON.
 
+  - name: type_string
+    description: |
+      Dependent on the adapter type, returns the native type for storing a string.
+
   ## MIGRATION ##
   - name: migrate_from_v0_to_v1
     description: |

--- a/macros/database_specific_helpers/type_helpers.sql
+++ b/macros/database_specific_helpers/type_helpers.sql
@@ -26,6 +26,10 @@
    json
 {% endmacro %}
 
+{% macro redshift__type_json() %}
+    varchar(max)
+{% endmacro %}
+
 {#- ARRAY -#}
 
 {% macro type_array() %}
@@ -42,4 +46,20 @@
 
 {% macro bigquery__type_array() %}
    array<string>
+{% endmacro %}
+
+{% macro redshift__type_array() %}
+    varchar(max)
+{% endmacro %}
+
+{% macro type_string() %}
+    {{ return(adapter.dispatch('type_string', 'dbt_artifacts')()) }}
+{% endmacro %}
+
+{% macro default__type_string() %}
+   {{ return(api.Column.translate_type("string")) }}
+{% endmacro %}
+
+{% macro redshift__type_string() %}
+    varchar(max)
 {% endmacro %}

--- a/tox.ini
+++ b/tox.ini
@@ -35,7 +35,7 @@ rules = LT01,LT02,LT03,CP01,AL01,AL02,CP02,ST08,LT06,LT07,AM01,LT08,AL05,RF02,RF
 # ST08: [structure.distinct] 'DISTINCT' used with parentheses.
 
 deps =
-    sqlfluff-templater-dbt~=2.0.2
+    sqlfluff-templater-dbt~=2.3.5
     dbt-snowflake~=1.7.0
 
 [sqlfluff:indentation]
@@ -69,6 +69,9 @@ profiles_dir = integration_test_project
 
 [testenv]
 passenv =
+    AWS_ACCESS_KEY_ID
+    AWS_SECRET_ACCESS_KEY
+    AWS_SESSION_TOKEN
     DBT_PROFILES_DIR
     GITHUB_SHA_OVERRIDE
     GITHUB_SHA
@@ -85,6 +88,10 @@ passenv =
     DBT_ENV_SECRET_GCP_PROJECT
     DBT_ENV_SPARK_DRIVER_PATH
     DBT_ENV_SPARK_ENDPOINT
+    DBT_ENV_SECRET_REDSHIFT_HOST
+    DBT_ENV_SECRET_REDSHIFT_CLUSTER_ID
+    DBT_ENV_SECRET_REDSHIFT_DB
+    DBT_ENV_SECRET_REDSHIFT_USER
     GOOGLE_APPLICATION_CREDENTIALS
     DBT_CLOUD_PROJECT_ID
     DBT_CLOUD_JOB_ID
@@ -264,6 +271,15 @@ commands =
     dbt clean
     dbt deps
     dbt build --target bigquery --vars '"my_var": "my value"'
+
+# Redshift integration test
+[testenv:integration_test_redshift]
+changedir = integration_test_project
+deps = dbt-redshift~=1.7.0
+commands =
+    dbt clean
+    dbt deps
+    dbt build --target redshift --vars '"my_var": "my value"'
 
 # Spark integration test (disabled)
 [testenv:integration_spark]


### PR DESCRIPTION
## Overview

Adding Redshift support - seems like with the new changes this is fairly trivial.  The only issue I had running the test suite was the one described in https://github.com/brooklyn-data/dbt_artifacts/issues/60.  

Which is trivially solvable (not necessarily in a nice way) by adding redshift specific dispatches for string type helpers that return a varchar(max).

## Update type - breaking / non-breaking

<!-- What type of update is this? -->
- [ ] Minor bug fix
- [ ] Documentation improvements
- [ ] Quality of Life improvements
- [x] New features (non-breaking change)
- [ ] New features (breaking change)
- [ ] Other (non-breaking change)
- [ ] Other (breaking change)
- [ ] Release preparation

## What does this solve?
https://github.com/brooklyn-data/dbt_artifacts/issues/60
Adding super basic redshift support as per issue 60. 

## Outstanding questions
It's a bit clunky using varchar(max) for these types, but it solves the issue without needing to know what the maximum possible length of each text field is and having a special dispatch which takes the length (that other databases don't care about).

And imo it's better to just add this support and then someone can optimise this later if they have a problem with varchar(max).

## What databases have you tested with?

<!-- You don't need to have tested with them all, but this helps us know which you have tried already -->
- [ ] Snowflake
- [ ] Google BigQuery
- [ ] Databricks
- [ ] Spark
- [x] Redshift
- [ ] N/A
