### PR TITLE
Fix: typo in upload_results to determine batch size

### DIFF
--- a/macros/upload_results/upload_results.sql
+++ b/macros/upload_results/upload_results.sql
@@ -19,7 +19,7 @@
             {% set objects = dbt_artifacts.get_dataset_content(dataset) %}
 
             {# Upload in chunks to reduce query size #}
-            {% if dataset == 'model' %}
+            {% if dataset == 'models' %}
                 {% set upload_limit = 50 if target.type == 'bigquery' else 100 %}
             {% else %}
                 {% set upload_limit = 300 if target.type == 'bigquery' else 5000 %}

--- a/macros/upload_results/upload_results.sql
+++ b/macros/upload_results/upload_results.sql
@@ -18,7 +18,7 @@
             {# Get the results that need to be uploaded #}
             {% set objects = dbt_artifacts.get_dataset_content(dataset) %}
 
-            {# Upload in chunks to reduce query size #}
+            {# Upload in chunks to reduce the query size #}
             {% if dataset == 'models' %}
                 {% set upload_limit = 50 if target.type == 'bigquery' else 100 %}
             {% else %}


### PR DESCRIPTION
## Overview

<!-- In 1-2 sentences, provide an overview of what this PR does -->

Fixes a typo in `upload_results()` that causes batch sizes for uploading models to be too large _for BigQuery only_.

## Update type - breaking / non-breaking

<!-- What type of update is this? -->
- [x] Minor bug fix
- [ ] Documentation improvements
- [ ] Quality of Life improvements
- [ ] New features (non-breaking change)
- [ ] New features (breaking change)
- [ ] Other (non-breaking change)
- [ ] Other (breaking change)
- [ ] Release preparation

## What does this solve?

<!-- Include any links to relevant open issues -->

This typo caused the batch size for models in BigQuery to be too large, causing an error (due to a too-large query size) when uploading models. Testing the same changeset on a different fork in a separate (complex, but private) project successfully uploads models (where using the v2.6.2 release of dbt_artifacts causes the failure).

## Outstanding questions

<!-- Include any details here of issues you found along the way, or things that still require attention -->
N/A, this is a straightforward fix, I think!

## What databases have you tested with?

<!-- You don't need to have tested with them all, but this helps us know which you have tried already -->
- [ ] Snowflake
- [x] Google BigQuery
- [ ] Databricks
- [ ] Spark
- [ ] N/A

This changeset passes integration tests in BigQuery. I don't have access to other databases so haven't tested there (however, the change should only affect behaviour in BigQuery).