### PR TITLE
[Bug] Leave model intact when uploading

### DIFF
--- a/macros/upload_individual_datasets/upload_models.sql
+++ b/macros/upload_individual_datasets/upload_models.sql
@@ -24,22 +24,23 @@
             {{ adapter.dispatch('parse_json', 'dbt_artifacts')(adapter.dispatch('column_identifier', 'dbt_artifacts')(15)) }}
         from values
         {% for model in models -%}
-                {% do model.pop('raw_code', None) %}
+                {% set model_copy = model.copy() -%}
+                {% do model_copy.pop('raw_code', None) %}
             (
                 '{{ invocation_id }}', {# command_invocation_id #}
-                '{{ model.unique_id }}', {# node_id #}
+                '{{ model_copy.unique_id }}', {# node_id #}
                 '{{ run_started_at }}', {# run_started_at #}
-                '{{ model.database }}', {# database #}
-                '{{ model.schema }}', {# schema #}
-                '{{ model.name }}', {# name #}
-                '{{ tojson(model.depends_on.nodes) | replace('\\', '\\\\') }}', {# depends_on_nodes #}
-                '{{ model.package_name }}', {# package_name #}
-                '{{ model.original_file_path | replace('\\', '\\\\') }}', {# path #}
-                '{{ model.checksum.checksum  | replace('\\', '\\\\') }}', {# checksum #}
-                '{{ model.config.materialized }}', {# materialization #}
-                '{{ tojson(model.tags) }}', {# tags #}
-                '{{ tojson(model.config.meta) | replace("\\", "\\\\") | replace("'","\\'") | replace('"', '\\"') }}', {# meta #}
-                '{{ model.alias }}', {# alias #}
+                '{{ model_copy.database }}', {# database #}
+                '{{ model_copy.schema }}', {# schema #}
+                '{{ model_copy.name }}', {# name #}
+                '{{ tojson(model_copy.depends_on.nodes) | replace('\\', '\\\\') }}', {# depends_on_nodes #}
+                '{{ model_copy.package_name }}', {# package_name #}
+                '{{ model_copy.original_file_path | replace('\\', '\\\\') }}', {# path #}
+                '{{ model_copy.checksum.checksum  | replace('\\', '\\\\') }}', {# checksum #}
+                '{{ model_copy.config.materialized }}', {# materialization #}
+                '{{ tojson(model_copy.tags) }}', {# tags #}
+                '{{ tojson(model_copy.config.meta) | replace("\\", "\\\\") | replace("'","\\'") | replace('"', '\\"') }}', {# meta #}
+                '{{ model_copy.alias }}', {# alias #}
                 {% if var('dbt_artifacts_exclude_all_results', false) %}
                     null
                 {% else %}
@@ -59,22 +60,23 @@
     {% if models != [] %}
         {% set model_values %}
             {% for model in models -%}
-                {% do model.pop('raw_code', None) %}
+                {% set model_copy = model.copy() -%}
+                {% do model_copy.pop('raw_code', None) %}
                 (
                     '{{ invocation_id }}', {# command_invocation_id #}
-                    '{{ model.unique_id }}', {# node_id #}
+                    '{{ model_copy.unique_id }}', {# node_id #}
                     '{{ run_started_at }}', {# run_started_at #}
-                    '{{ model.database }}', {# database #}
-                    '{{ model.schema }}', {# schema #}
-                    '{{ model.name }}', {# name #}
-                    {{ tojson(model.depends_on.nodes) }}, {# depends_on_nodes #}
-                    '{{ model.package_name }}', {# package_name #}
-                    '{{ model.original_file_path | replace('\\', '\\\\') }}', {# path #}
-                    '{{ model.checksum.checksum | replace('\\', '\\\\') }}', {# checksum #}
-                    '{{ model.config.materialized }}', {# materialization #}
-                    {{ tojson(model.tags) }}, {# tags #}
-                    {{ adapter.dispatch('parse_json', 'dbt_artifacts')(tojson(model.config.meta)) }}, {# meta #}
-                    '{{ model.alias }}', {# alias #}
+                    '{{ model_copy.database }}', {# database #}
+                    '{{ model_copy.schema }}', {# schema #}
+                    '{{ model_copy.name }}', {# name #}
+                    {{ tojson(model_copy.depends_on.nodes) }}, {# depends_on_nodes #}
+                    '{{ model_copy.package_name }}', {# package_name #}
+                    '{{ model_copy.original_file_path | replace('\\', '\\\\') }}', {# path #}
+                    '{{ model_copy.checksum.checksum | replace('\\', '\\\\') }}', {# checksum #}
+                    '{{ model_copy.config.materialized }}', {# materialization #}
+                    {{ tojson(model_copy.tags) }}, {# tags #}
+                    {{ adapter.dispatch('parse_json', 'dbt_artifacts')(tojson(model_copy.config.meta)) }}, {# meta #}
+                    '{{ model_copy.alias }}', {# alias #}
                     {% if var('dbt_artifacts_exclude_all_results', false) %}
                         null
                     {% else %}
@@ -94,22 +96,23 @@
     {% if models != [] %}
         {% set model_values %}
             {% for model in models -%}
-                {% do model.pop('raw_code', None) %}
+                {% set model_copy = model.copy() -%}
+                {% do model_copy.pop('raw_code', None) %}
                 (
                     '{{ invocation_id }}', {# command_invocation_id #}
-                    '{{ model.unique_id }}', {# node_id #}
+                    '{{ model_copy.unique_id }}', {# node_id #}
                     '{{ run_started_at }}', {# run_started_at #}
-                    '{{ model.database }}', {# database #}
-                    '{{ model.schema }}', {# schema #}
-                    '{{ model.name }}', {# name #}
-                    '{{ tojson(model.depends_on.nodes) }}', {# depends_on_nodes #}
-                    '{{ model.package_name }}', {# package_name #}
-                    $${{ model.original_file_path | replace('\\', '\\\\') }}$$, {# path #}
-                    '{{ model.checksum.checksum }}', {# checksum #}
-                    '{{ model.config.materialized }}', {# materialization #}
-                    '{{ tojson(model.tags) }}', {# tags #}
-                    $${{ model.config.meta }}$$, {# meta #}
-                    '{{ model.alias }}', {# alias #}
+                    '{{ model_copy.database }}', {# database #}
+                    '{{ model_copy.schema }}', {# schema #}
+                    '{{ model_copy.name }}', {# name #}
+                    '{{ tojson(model_copy.depends_on.nodes) }}', {# depends_on_nodes #}
+                    '{{ model_copy.package_name }}', {# package_name #}
+                    $${{ model_copy.original_file_path | replace('\\', '\\\\') }}$$, {# path #}
+                    '{{ model_copy.checksum.checksum }}', {# checksum #}
+                    '{{ model_copy.config.materialized }}', {# materialization #}
+                    '{{ tojson(model_copy.tags) }}', {# tags #}
+                    $${{ model_copy.config.meta }}$$, {# meta #}
+                    '{{ model_copy.alias }}', {# alias #}
                     {% if var('dbt_artifacts_exclude_all_results', false) %}
                         null
                     {% else %}

--- a/macros/upload_individual_datasets/upload_models.sql
+++ b/macros/upload_individual_datasets/upload_models.sql
@@ -80,7 +80,7 @@
                     {% if var('dbt_artifacts_exclude_all_results', false) %}
                         null
                     {% else %}
-                        {{ adapter.dispatch('parse_json', 'dbt_artifacts')(tojson(model) | replace("\\", "\\\\") | replace("'","\\'") | replace('"', '\\"')) }} {# all_results #}
+                        {{ adapter.dispatch('parse_json', 'dbt_artifacts')(tojson(model_copy) | replace("\\", "\\\\") | replace("'","\\'") | replace('"', '\\"')) }} {# all_results #}
                     {% endif %}
                 )
                 {%- if not loop.last %},{%- endif %}
@@ -116,7 +116,7 @@
                     {% if var('dbt_artifacts_exclude_all_results', false) %}
                         null
                     {% else %}
-                        $${{ tojson(model) }}$$ {# all_results #}
+                        $${{ tojson(model_copy) }}$$ {# all_results #}
                     {% endif %}
                 )
                 {%- if not loop.last %},{%- endif %}

--- a/macros/upload_individual_datasets/upload_models.sql
+++ b/macros/upload_individual_datasets/upload_models.sql
@@ -44,7 +44,7 @@
                 {% if var('dbt_artifacts_exclude_all_results', false) %}
                     null
                 {% else %}
-                    '{{ tojson(model) | replace("\\", "\\\\") | replace("'","\\'") | replace('"', '\\"') }}' {# all_results #}
+                    '{{ tojson(model_copy) | replace("\\", "\\\\") | replace("'","\\'") | replace('"', '\\"') }}' {# all_results #}
                 {% endif %}
             )
             {%- if not loop.last %},{%- endif %}


### PR DESCRIPTION
## Overview

When models are uploaded, the `raw_code` attribute is dropped - presumably for size concerns.  This can cause problems with other DBT packages that expect this attribute to be present.

This PR shifts the model uploading macros to work on copies of the model object, rather than the original. This should mean that any changes won't affect the use of these object elsewhere.

## Update type - breaking / non-breaking

<!-- What type of update is this? -->
- [x] Minor bug fix
- [ ] Documentation improvements
- [ ] Quality of Life improvements
- [ ] New features (non-breaking change)
- [ ] New features (breaking change)
- [ ] Other (non-breaking change)
- [ ] Other (breaking change)
- [ ] Release preparation

## What does this solve?

Incompatibility with other DBT packages. See issue https://github.com/brooklyn-data/dbt_artifacts/issues/414

## Outstanding questions

<!-- Include any details here of issues you found along the way, or things that still require attention -->

## What databases have you tested with?

I'm unable to test this, but we have patched this fix in to our DBT codebase already.

<!-- You don't need to have tested with them all, but this helps us know which you have tried already -->
- [ ] Snowflake
- [ ] Google BigQuery
- [ ] Databricks
- [ ] Spark
- [x] N/A
