### PR TITLE
Fix get_test_executions_dml_sql timing

### DIFF
--- a/macros/upload_individual_datasets/upload_test_executions.sql
+++ b/macros/upload_individual_datasets/upload_test_executions.sql
@@ -35,9 +35,9 @@
                 '{{ test.thread_id }}', {# thread_id #}
                 '{{ test.status }}', {# status #}
 
-                {% set compile_started_at = (model.timing | selectattr("name", "eq", "compile") | first | default({}))["started_at"] %}
+                {% set compile_started_at = (test.timing | selectattr("name", "eq", "compile") | first | default({}))["started_at"] %}
                 {% if compile_started_at %}'{{ compile_started_at }}'{% else %}null{% endif %}, {# compile_started_at #}
-                {% set query_completed_at = (model.timing | selectattr("name", "eq", "execute") | first | default({}))["completed_at"] %}
+                {% set query_completed_at = (test.timing | selectattr("name", "eq", "execute") | first | default({}))["completed_at"] %}
                 {% if query_completed_at %}'{{ query_completed_at }}'{% else %}null{% endif %}, {# query_completed_at #}
 
                 {{ test.execution_time }}, {# total_node_runtime #}
@@ -73,9 +73,9 @@
                 '{{ test.thread_id }}', {# thread_id #}
                 '{{ test.status }}', {# status #}
 
-                {% set compile_started_at = (model.timing | selectattr("name", "eq", "compile") | first | default({}))["started_at"] %}
+                {% set compile_started_at = (test.timing | selectattr("name", "eq", "compile") | first | default({}))["started_at"] %}
                 {% if compile_started_at %}'{{ compile_started_at }}'{% else %}null{% endif %}, {# compile_started_at #}
-                {% set query_completed_at = (model.timing | selectattr("name", "eq", "execute") | first | default({}))["completed_at"] %}
+                {% set query_completed_at = (test.timing | selectattr("name", "eq", "execute") | first | default({}))["completed_at"] %}
                 {% if query_completed_at %}'{{ query_completed_at }}'{% else %}null{% endif %}, {# query_completed_at #}
 
                 {{ test.execution_time }}, {# total_node_runtime #}
@@ -141,6 +141,59 @@
             )
             {%- if not loop.last %},{%- endif %}
 
+        {%- endfor %}
+        {% endset %}
+        {{ test_execution_values }}
+    {% else %}
+        {{ return("") }}
+    {% endif %}
+{% endmacro -%}
+
+{% macro snowflake_get_test_executions_dml_sql(tests) -%}
+    {% if tests != [] %}
+        {% set test_execution_values %}
+        select
+            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(1) }},
+            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(2) }},
+            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(3) }},
+            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(4) }},
+            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(5) }},
+            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(6) }},
+            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(7) }},
+            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(8) }},
+            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(9) }},
+            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(10) }},
+            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(11) }},
+            {{ adapter.dispatch('column_identifier', 'dbt_artifacts')(12) }},
+            {{ adapter.dispatch('parse_json', 'dbt_artifacts')(adapter.dispatch('column_identifier', 'dbt_artifacts')(13)) }}
+        from values
+        {% for test in tests -%}
+            (
+                '{{ invocation_id }}', {# command_invocation_id #}
+                '{{ test.node.unique_id }}', {# node_id #}
+                '{{ run_started_at }}', {# run_started_at #}
+
+                {% set config_full_refresh = test.node.config.full_refresh %}
+                {% if config_full_refresh is none %}
+                    {% set config_full_refresh = flags.FULL_REFRESH %}
+                {% endif %}
+                '{{ config_full_refresh }}', {# was_full_refresh #}
+
+                '{{ test.thread_id }}', {# thread_id #}
+                '{{ test.status }}', {# status #}
+
+                {% set compile_started_at = (test.timing | selectattr("name", "eq", "compile") | first | default({}))["started_at"] %}
+                {% if compile_started_at %}'{{ compile_started_at }}'{% else %}null{% endif %}, {# compile_started_at #}
+                {% set query_completed_at = (test.timing | selectattr("name", "eq", "execute") | first | default({}))["completed_at"] %}
+                {% if query_completed_at %}'{{ query_completed_at }}'{% else %}null{% endif %}, {# query_completed_at #}
+
+                {{ test.execution_time }}, {# total_node_runtime #}
+                try_cast('{{ model.adapter_response.rows_affected }}' as int), {# rows_affected #}
+                {{ 'null' if test.failures is none else test.failures }}, {# failures #}
+                '{{ test.message | replace("\\", "\\\\") | replace("'", "\\'") | replace('"', '\\"') }}', {# message #}
+                '{{ tojson(test.adapter_response) | replace("\\", "\\\\") | replace("'", "\\'") | replace('"', '\\"') }}' {# adapter_response #}
+            )
+            {%- if not loop.last %},{%- endif %}
         {%- endfor %}
         {% endset %}
         {{ test_execution_values }}

--- a/macros/upload_individual_datasets/upload_test_executions.sql
+++ b/macros/upload_individual_datasets/upload_test_executions.sql
@@ -188,7 +188,7 @@
                 {% if query_completed_at %}'{{ query_completed_at }}'{% else %}null{% endif %}, {# query_completed_at #}
 
                 {{ test.execution_time }}, {# total_node_runtime #}
-                try_cast('{{ model.adapter_response.rows_affected }}' as int), {# rows_affected #}
+                try_cast('{{ test.adapter_response.rows_affected }}' as int), {# rows_affected #}
                 {{ 'null' if test.failures is none else test.failures }}, {# failures #}
                 '{{ test.message | replace("\\", "\\\\") | replace("'", "\\'") | replace('"', '\\"') }}', {# message #}
                 '{{ tojson(test.adapter_response) | replace("\\", "\\\\") | replace("'", "\\'") | replace('"', '\\"') }}' {# adapter_response #}

--- a/macros/upload_individual_datasets/upload_test_executions.sql
+++ b/macros/upload_individual_datasets/upload_test_executions.sql
@@ -149,7 +149,7 @@
     {% endif %}
 {% endmacro -%}
 
-{% macro snowflake_get_test_executions_dml_sql(tests) -%}
+{% macro snowflake__get_test_executions_dml_sql(tests) -%}
     {% if tests != [] %}
         {% set test_execution_values %}
         select


### PR DESCRIPTION
## Overview

<!-- In 1-2 sentences, provide an overview of what this PR does -->

* Implementation of get_test_executions_dml_sql has code that references `model.timing`. Local loop variable is `test`, not `model`. Revised code to use `test` instead of `model`.

* Implemented snowflake_get_test_executions_dml_sql to support rows_affected.


## Update type - breaking / non-breaking

<!-- What type of update is this? -->
- [ * ] Minor bug fix
- [ ] Documentation improvements
- [ ] Quality of Life improvements
- [ ] New features (non-breaking change)
- [ ] New features (breaking change)
- [ ] Other (non-breaking change)
- [ ] Other (breaking change)
- [ ] Release preparation

## What does this solve?

<!-- Include any links to relevant open issues -->

## Outstanding questions

<!-- Include any details here of issues you found along the way, or things that still require attention -->

## What databases have you tested with?

<!-- You don't need to have tested with them all, but this helps us know which you have tried already -->
- [ * ] Snowflake
- [ ] Google BigQuery
- [ ] Databricks
- [ ] Spark
- [ ] N/A
