### PR TITLE
Bugfix/fix ci lint error

### DIFF
--- a/.github/workflows/ci_lint_package.yml
+++ b/.github/workflows/ci_lint_package.yml
@@ -50,7 +50,7 @@ jobs:
           architecture: "x64"
 
       - name: Install Python packages
-        run: python -m pip install dbt-snowflake~=1.8.0 sqlfluff-templater-dbt~=2.3.2
+        run: python -m pip install dbt-snowflake~=1.8.0 sqlfluff-templater-dbt~=3.0.0
 
       - name: Test database connection
         run: dbt debug

--- a/.github/workflows/main_lint_package.yml
+++ b/.github/workflows/main_lint_package.yml
@@ -46,7 +46,7 @@ jobs:
           architecture: "x64"
 
       - name: Install Python packages
-        run: python -m pip install dbt-snowflake~=1.8.0 sqlfluff-templater-dbt~=2.3.2
+        run: python -m pip install dbt-snowflake~=1.8.0 sqlfluff-templater-dbt~=3.0.0
 
       - name: Test database connection
         run: dbt debug


### PR DESCRIPTION
## Overview

Update sqlfluff used in CI to version ~3.0 to fix import error introduced in certain dbt versions

## Update type - breaking / non-breaking

<!-- What type of update is this? -->
- [x] Minor bug fix
- [ ] Documentation improvements
- [ ] Quality of Life improvements
- [ ] New features (non-breaking change)
- [ ] New features (breaking change)
- [ ] Other (non-breaking change)
- [ ] Other (breaking change)
- [ ] Release preparation

