### PR TITLE
[FIX] Modify Snowflake parse_json macro usage

### DIFF
--- a/macros/database_specific_helpers/parse_json.sql
+++ b/macros/database_specific_helpers/parse_json.sql
@@ -7,7 +7,7 @@
 {%- endmacro %}
 
 {% macro snowflake__parse_json(field) -%}
-    parse_json({{ field }})
+    try_parse_json({{ field }})
 {%- endmacro %}
 
 {% macro bigquery__parse_json(field) -%}


### PR DESCRIPTION
## Overview

Modifies the Snowflake `parse_json` macro to use `try` in case json is invalid.

## Update type - breaking / non-breaking

<!-- What type of update is this? -->
- [x] Minor bug fix
- [ ] Documentation improvements
- [ ] Quality of Life improvements
- [ ] New features (non-breaking change)
- [ ] New features (breaking change)
- [ ] Other (non-breaking change)
- [ ] Other (breaking change)
- [ ] Release preparation

## What does this solve?

Resolves [Bug]: Parsing Error in dbt Artifacts JSON Conversion of Source with Case-Sensitive Column Names in Filters for dbt freshness #419 

## Outstanding questions

NA

## What databases have you tested with?

<!-- You don't need to have tested with them all, but this helps us know which you have tried already -->
- [x] Snowflake
- [ ] Google BigQuery
- [ ] Databricks
- [ ] Spark
- [ ] N/A
