### PR TITLE
Patch: Update tox.ini to handle dbt-postgres installing dbt-core prerelease

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -299,7 +299,9 @@ commands =
 
 [testenv:integration_postgres]
 changedir = integration_test_project
-deps = dbt-postgres~=1.8.0
+deps =
+    dbt-core~=1.8.0
+    dbt-postgres~=1.8.0
 commands =
     dbt clean
     dbt deps
@@ -347,7 +349,9 @@ commands =
 
 [testenv:integration_postgres_1_8_0]
 changedir = integration_test_project
-deps = dbt-postgres~=1.7.0
+deps =
+    dbt-core~=1.8.0
+    dbt-postgres~=1.8.0
 commands =
     dbt clean
     dbt deps


### PR DESCRIPTION
## Overview
This PR adds an additional dependency in the tox.ini file to ensure dbt-postgres installs dbt-core 1.8.x. Without this dependency, it installs dbt-core 1.9.0b1

## Update type - breaking / non-breaking

<!-- What type of update is this? -->
- [X] Minor bug fix
- [ ] Documentation improvements
- [ ] Quality of Life improvements
- [ ] New features (non-breaking change)
- [ ] New features (breaking change)
- [ ] Other (non-breaking change)
- [ ] Other (breaking change)
- [ ] Release preparation

## What does this solve?
This solves open PRs that cannot pass CI due to tox.ini installing a pre-release version of dbt-core for dbt-postgres adapter. This means we violate the `require-dbt-version` parameter in the `dbt_project.yml` fle.

## Outstanding questions

<!-- Include any details here of issues you found along the way, or things that still require attention -->

## What databases have you tested with?

<!-- You don't need to have tested with them all, but this helps us know which you have tried already -->
- [ ] Snowflake
- [ ] Google BigQuery
- [ ] Databricks
- [ ] Spark
- [X] N/A
