### PR TITLE
Update dbt_artifacts to 2.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ See the generated [dbt docs site](https://brooklyn-data.github.io/dbt_artifacts/
 ```
 packages:
   - package: brooklyn-data/dbt_artifacts
-    version: 2.6.4
+    version: 2.7.0
 ```
 
 :construction_worker: Make sure to fix at least the **minor** version, to avoid issues when a new release is open. See the notes on upgrading below for more detail.

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: "dbt_artifacts"
-version: "2.6.4"
+version: "2.7.0"
 config-version: 2
 require-dbt-version: [">=1.3.0", "<1.9.0"]
 profile: "dbt_artifacts"


### PR DESCRIPTION
## Overview
This PR updates the latest version to 2.7.0. This includes new functionality and bug fixes.

## Update type - breaking / non-breaking

<!-- What type of update is this? -->
- [ ] Minor bug fix
- [ ] Documentation improvements
- [ ] Quality of Life improvements
- [ ] New features (non-breaking change)
- [ ] New features (breaking change)
- [ ] Other (non-breaking change)
- [ ] Other (breaking change)
- [X] Release preparation

## What does this solve?
Notably solves a bug where tox.ini is installing a pre-release version of dbt-core.

## Outstanding questions

<!-- Include any details here of issues you found along the way, or things that still require attention -->

## What databases have you tested with?

<!-- You don't need to have tested with them all, but this helps us know which you have tried already -->
- [ ] Snowflake
- [ ] Google BigQuery
- [ ] Databricks
- [ ] Spark
- [ ] N/A
