### PR TITLE
Testing #445 - adding sqlserver integration tests

### DIFF
--- a/.github/workflows/ci_test_package.yml
+++ b/.github/workflows/ci_test_package.yml
@@ -193,3 +193,86 @@ jobs:
   #       env:
   #         DBT_VERSION: ''
   #       run: tox -e integration_databricks
+
+  integration-sqlserver:
+    strategy:
+      fail-fast: false # Don't fail one DWH if the others fail
+    runs-on: ubuntu-latest
+    environment:
+      name: Approve Integration Tests
+
+    steps:
+    - uses: actions/setup-python@v4
+      with:
+        python-version: "3.8.x"
+        architecture: "x64"
+    - name: Install SQL Server
+      uses: Particular/install-sql-server-action@v1.2.0
+      with:
+        connection-string-env-var: SQL_SERVER_CONNECTION_STRING
+        catalog: dbt_artifact_integrationtests
+    - name: Create DBT User
+      shell: pwsh
+      run: |
+          echo "Create dbt login with sysadmin"
+          sqlcmd -Q "CREATE LOGIN dbt WITH PASSWORD = '123', CHECK_POLICY = OFF, CHECK_EXPIRATION = OFF" -d "dbt_artifact_integrationtests"
+          sqlcmd -Q "ALTER SERVER ROLE sysadmin ADD MEMBER dbt" -d "dbt_artifact_integrationtests"
+    - name: Install tox
+      run: python3 -m pip install tox
+
+    - name: Install Microsoft ODBC
+      run: sudo ACCEPT_EULA=Y apt-get install msodbcsql18 -y
+
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }} # Check out the code of the PR
+
+    - name: Run Tests on PR
+      env:
+        DBT_VERSION: ${{ matrix.version }}
+      run: tox -e integration_sqlserver
+
+  integration-sqlserver-single-run:
+    strategy:
+      fail-fast: false # Don't fail one DWH if the others fail
+      matrix:
+        # When supporting a new version, update the list here
+        version: ["1_3_0", "1_4_0", "1_7_0", "1_8_0"]
+        run: tox -e integration_sqlserver_${{ matrix.version }}
+        runs-on: ubuntu-latest
+        environment:
+          name: Approve Integration Tests
+
+        steps:
+        - uses: actions/setup-python@v4
+          with:
+            python-version: "3.8.x"
+            architecture: "x64"
+        - name: Install SQL Server
+          uses: Particular/install-sql-server-action@v1.2.0
+          with:
+            connection-string-env-var: SQL_SERVER_CONNECTION_STRING
+            catalog: dbt_artifact_integrationtests
+        - name: Create DBT User
+          shell: pwsh
+          run: |
+              echo "Create dbt login with sysadmin"
+              sqlcmd -Q "CREATE LOGIN dbt WITH PASSWORD = '123', CHECK_POLICY = OFF, CHECK_EXPIRATION = OFF" -d "dbt_artifact_integrationtests"
+              sqlcmd -Q "ALTER SERVER ROLE sysadmin ADD MEMBER dbt" -d "dbt_artifact_integrationtests"
+        - name: Install tox
+          run: python3 -m pip install tox
+
+        - name: Install Microsoft ODBC
+          run: sudo ACCEPT_EULA=Y apt-get install msodbcsql18 -y
+
+        - name: Checkout
+          uses: actions/checkout@v3
+          with:
+            ref: ${{ github.event.pull_request.head.sha }} # Check out the code of the PR
+
+        - name: Run Tests on PR
+          env:
+            DBT_VERSION: ${{ matrix.version }}
+            run: tox -e integration_sqlserver_${{ matrix.version }}
+

--- a/.github/workflows/main_test_package.yml
+++ b/.github/workflows/main_test_package.yml
@@ -34,7 +34,7 @@ jobs:
   integration:
     strategy:
       matrix:
-        warehouse: ["snowflake", "bigquery", "postgres", "sqlserver"]
+        warehouse: ["snowflake", "bigquery", "postgres"]
         version: ["1_3_0", "1_4_0", "1_5_0", "1_6_0", "1_7_0", "1_8_0"]
     runs-on: ubuntu-latest
     permissions:
@@ -102,3 +102,45 @@ jobs:
 
   #     - name: Run Databricks Tests
   #       run: tox -e integration_databricks
+
+  integration-sqlserver:
+    strategy:
+      fail-fast: false # Don't fail one DWH if the others fail
+      matrix:
+        # When supporting a new version, update the list here
+        version: ["1_3_0", "1_4_0", "1_7_0", "1_8_0"]
+    runs-on: ubuntu-latest
+    environment:
+      name: Approve Integration Tests
+
+    steps:
+    - uses: actions/setup-python@v4
+      with:
+        python-version: "3.8.x"
+        architecture: "x64"
+    - name: Install SQL Server
+      uses: Particular/install-sql-server-action@v1.2.0
+      with:
+        connection-string-env-var: SQL_SERVER_CONNECTION_STRING
+        catalog: dbt_artifact_integrationtests
+    - name: Create DBT User
+      shell: pwsh
+      run: |
+          echo "Create dbt login with sysadmin"
+          sqlcmd -Q "CREATE LOGIN dbt WITH PASSWORD = '123', CHECK_POLICY = OFF, CHECK_EXPIRATION = OFF" -d "dbt_artifact_integrationtests"
+          sqlcmd -Q "ALTER SERVER ROLE sysadmin ADD MEMBER dbt" -d "dbt_artifact_integrationtests"
+    - name: Install tox
+      run: python3 -m pip install tox
+
+    - name: Install Microsoft ODBC
+      run: sudo ACCEPT_EULA=Y apt-get install msodbcsql18 -y
+
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }} # Check out the code of the PR
+
+    - name: Run Tests on PR
+      env:
+        DBT_VERSION: ${{ matrix.version }}
+      run: tox -e integration_sqlserver_${{ matrix.version }}

--- a/integration_test_project/profiles.yml
+++ b/integration_test_project/profiles.yml
@@ -61,5 +61,6 @@ dbt_artifacts:
       schema: dbo
       windows_login: False
       trust_cert: True
-      user: sa
+      Encrypt: False
+      user: dbt
       password: "123"

--- a/tox.ini
+++ b/tox.ini
@@ -359,31 +359,39 @@ commands =
 
 [testenv:integration_sqlserver]
 changedir = integration_test_project
-deps = dbt-sqlserver~=1.8.4
+deps = dbt-sqlserver~=1.8.0
 commands =
     dbt clean
     dbt deps
     dbt build --target sqlserver
 
-[testenv:integration_sqlserver_1_4_3]
+[testenv:integration_sqlserver_1_3_0]
 changedir = integration_test_project
-deps = dbt-sqlserver~=1.4.3
+deps = dbt-sqlserver~=1.3.0
 commands =
     dbt clean
     dbt deps
     dbt build --target sqlserver
 
-[testenv:integration_sqlserver_1_7_4]
+[testenv:integration_sqlserver_1_4_0]
 changedir = integration_test_project
-deps = dbt-sqlserver~=1.7.4
+deps = dbt-sqlserver~=1.4.0
 commands =
     dbt clean
     dbt deps
     dbt build --target sqlserver
 
-[testenv:integration_sqlserver_1_8_4]
+[testenv:integration_sqlserver_1_7_0]
 changedir = integration_test_project
-deps = dbt-sqlserver~=1.8.4
+deps = dbt-sqlserver~=1.7.0
+commands =
+    dbt clean
+    dbt deps
+    dbt build --target sqlserver
+
+[testenv:integration_sqlserver_1_8_0]
+changedir = integration_test_project
+deps = dbt-sqlserver~=1.8.0
 commands =
     dbt clean
     dbt deps


### PR DESCRIPTION
## Overview

This PR is a copy of #445, necessary since we upgraded dbt-artifacts to version 1.7.0. This is a minor bug fix for the sqlserver github action. The bug is the connection to sqlserver in the test_packages and the profiles.yml.
 
## Update type - breaking / non-breaking

<!-- What type of update is this? -->
- [x] Minor bug fix
- [ ] Documentation improvements
- [ ] Quality of Life improvements
- [ ] New features (non-breaking change)
- [ ] New features (breaking change)
- [ ] Other (non-breaking change)
- [ ] Other (breaking change)
- [ ] Release preparation

## What does this solve?

<!-- Include any links to relevant open issues -->

## Outstanding questions

<!-- Include any details here of issues you found along the way, or things that still require attention -->

## What databases have you tested with?

<!-- You don't need to have tested with them all, but this helps us know which you have tried already -->
- [ ] Snowflake
- [ ] Google BigQuery
- [ ] Databricks
- [ ] Spark
- [ ] N/A
