### PR TITLE
Add support for v1.9

### DIFF
--- a/.github/workflows/ci_lint_package.yml
+++ b/.github/workflows/ci_lint_package.yml
@@ -50,7 +50,7 @@ jobs:
           architecture: "x64"
 
       - name: Install Python packages
-        run: python -m pip install dbt-snowflake~=1.8.0 sqlfluff-templater-dbt~=3.0.0
+        run: python -m pip install dbt-snowflake~=1.9.0 sqlfluff-templater-dbt~=3.0.0
 
       - name: Test database connection
         run: dbt debug

--- a/.github/workflows/ci_test_package.yml
+++ b/.github/workflows/ci_test_package.yml
@@ -21,7 +21,7 @@ env:
   DBT_ENV_SECRET_DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
   DBT_ENV_SECRET_GCP_PROJECT: ${{ secrets.GCP_PROJECT }}
   # Env var to test version
-  LAST_RELEASE_SUPPORTED_DBT_VERSION: 1_8_0 # A dbt version supported by both the last release and this one
+  LAST_RELEASE_SUPPORTED_DBT_VERSION: 1_9_0 # A dbt version supported by both the last release and this one
   # Env vars to test invocations model
   DBT_CLOUD_PROJECT_ID: 123
   DBT_CLOUD_JOB_ID: ABC
@@ -115,7 +115,7 @@ jobs:
       matrix:
         warehouse: ["snowflake", "bigquery", "postgres", "sqlserver"]
         # When supporting a new version, update the list here
-        version: ["1_3_0", "1_4_0", "1_5_0", "1_6_0", "1_7_0", "1_8_0"]
+        version: ["1_3_0", "1_4_0", "1_5_0", "1_6_0", "1_7_0", "1_8_0", "1_9_0"]
     runs-on: ubuntu-latest
     environment:
       name: Approve Integration Tests

--- a/.github/workflows/main_lint_package.yml
+++ b/.github/workflows/main_lint_package.yml
@@ -46,7 +46,7 @@ jobs:
           architecture: "x64"
 
       - name: Install Python packages
-        run: python -m pip install dbt-snowflake~=1.8.0 sqlfluff-templater-dbt~=3.0.0
+        run: python -m pip install dbt-snowflake~=1.9.0 sqlfluff-templater-dbt~=3.0.0
 
       - name: Test database connection
         run: dbt debug

--- a/.github/workflows/main_test_package.yml
+++ b/.github/workflows/main_test_package.yml
@@ -35,7 +35,7 @@ jobs:
     strategy:
       matrix:
         warehouse: ["snowflake", "bigquery", "postgres"]
-        version: ["1_3_0", "1_4_0", "1_5_0", "1_6_0", "1_7_0", "1_8_0"]
+        version: ["1_3_0", "1_4_0", "1_5_0", "1_6_0", "1_7_0", "1_8_0", "1_9_0"]
     runs-on: ubuntu-latest
     permissions:
       contents: "read"

--- a/.github/workflows/publish_docs_on_release.yml
+++ b/.github/workflows/publish_docs_on_release.yml
@@ -39,7 +39,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install Python packages
-        run: python -m pip install dbt-snowflake~=1.8.0
+        run: python -m pip install dbt-snowflake~=1.9.0
 
       - name: Test database connection
         run: dbt debug

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 name: "dbt_artifacts"
 version: "2.7.0"
 config-version: 2
-require-dbt-version: [">=1.3.0", "<1.9.0"]
+require-dbt-version: [">=1.3.0", "<1.10.0"]
 profile: "dbt_artifacts"
 
 clean-targets: # folders to be removed by `dbt clean`

--- a/tox.ini
+++ b/tox.ini
@@ -113,13 +113,13 @@ commands = sqlfluff fix models --ignore parsing
 
 # Generate docs
 [testenv:generate_docs]
-deps = dbt-snowflake~=1.8.0
+deps = dbt-snowflake~=1.9.0
 commands = dbt docs generate --profiles-dir integration_test_project
 
 # Snowflake integration tests
 [testenv:integration_snowflake]
 changedir = integration_test_project
-deps = dbt-snowflake~=1.8.0
+deps = dbt-snowflake~=1.9.0
 commands =
     dbt clean
     dbt deps
@@ -174,10 +174,18 @@ commands =
     dbt deps
     dbt build --target snowflake
 
+[testenv:integration_snowflake_1_9_0]
+changedir = integration_test_project
+deps = dbt-snowflake~=1.9.0
+commands =
+    dbt clean
+    dbt deps
+    dbt build --target snowflake
+
 # Databricks integration tests
 [testenv:integration_databricks]
 changedir = integration_test_project
-deps = dbt-databricks~=1.8.0
+deps = dbt-databricks~=1.9.0
 commands =
     dbt clean
     dbt deps
@@ -231,10 +239,18 @@ commands =
     dbt deps
     dbt build --target databricks
 
+[testenv:integration_databricks_1_9_0]
+changedir = integration_test_project
+deps = dbt-databricks~=1.9.0
+commands =
+    dbt clean
+    dbt deps
+    dbt build --target databricks
+
 # Bigquery integration tests
 [testenv:integration_bigquery]
 changedir = integration_test_project
-deps = dbt-bigquery~=1.8.0
+deps = dbt-bigquery~=1.9.0
 commands =
     dbt clean
     dbt deps
@@ -288,6 +304,14 @@ commands =
     dbt deps
     dbt build --target bigquery --vars '"my_var": "my value"'
 
+[testenv:integration_bigquery_1_9_0]
+changedir = integration_test_project
+deps = dbt-bigquery~=1.9.0
+commands =
+    dbt clean
+    dbt deps
+    dbt build --target bigquery --vars '"my_var": "my value"'
+
 # Spark integration test (disabled)
 [testenv:integration_spark]
 changedir = integration_test_project
@@ -300,8 +324,8 @@ commands =
 [testenv:integration_postgres]
 changedir = integration_test_project
 deps =
-    dbt-core~=1.8.0
-    dbt-postgres~=1.8.0
+    dbt-core~=1.9.0
+    dbt-postgres~=1.9.0
 commands =
     dbt clean
     dbt deps
@@ -352,6 +376,16 @@ changedir = integration_test_project
 deps =
     dbt-core~=1.8.0
     dbt-postgres~=1.8.0
+commands =
+    dbt clean
+    dbt deps
+    dbt build --target postgres
+
+[testenv:integration_postgres_1_9_0]
+changedir = integration_test_project
+deps =
+    dbt-core~=1.9.0
+    dbt-postgres~=1.9.0
 commands =
     dbt clean
     dbt deps


### PR DESCRIPTION
## Overview

Adds support for v1.9.

## Update type - breaking / non-breaking

<!-- What type of update is this? -->
- [ ] Minor bug fix
- [ ] Documentation improvements
- [ ] Quality of Life improvements
- [ ] New features (non-breaking change)
- [ ] New features (breaking change)
- [ ] Other (non-breaking change)
- [ ] Other (breaking change)
- [ ] Release preparation

## What does this solve?

<!-- Include any links to relevant open issues -->

## Outstanding questions
- The latest release of the [dbt SQL Server adapter](https://github.com/dbt-msft/dbt-sqlserver) is `1.8.5` so the `single-run-different-versions` step for `sqlserver` will fail in CI test package workflow
<!-- Include any details here of issues you found along the way, or things that still require attention -->

## What databases have you tested with?

<!-- You don't need to have tested with them all, but this helps us know which you have tried already -->
- [ ] Snowflake
- [ ] Google BigQuery
- [ ] Databricks
- [ ] Spark
- [ ] N/A
