### PR TITLE
Update indentation on ci_test_package.yml and Python 3.8 to 3.9

### DIFF
--- a/.github/workflows/ci_test_package.yml
+++ b/.github/workflows/ci_test_package.yml
@@ -74,7 +74,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10.x"
+          python-version: "3.9.x"
           architecture: "x64"
 
       - name: Install tox
@@ -139,7 +139,7 @@ jobs:
     steps:
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10.x"
+          python-version: "3.9.x"
           architecture: "x64"
 
       - name: Install tox
@@ -204,7 +204,7 @@ jobs:
     steps:
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10.x"
+          python-version: "3.9.x"
           architecture: "x64"
       - name: Install SQL Server
         uses: Particular/install-sql-server-action@v1.2.0
@@ -246,7 +246,7 @@ jobs:
     steps:
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10.x"
+          python-version: "3.9.x"
           architecture: "x64"
       - name: Install SQL Server
         uses: Particular/install-sql-server-action@v1.2.0

--- a/.github/workflows/ci_test_package.yml
+++ b/.github/workflows/ci_test_package.yml
@@ -74,7 +74,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.8.x"
+          python-version: "3.10.x"
           architecture: "x64"
 
       - name: Install tox
@@ -139,7 +139,7 @@ jobs:
     steps:
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.8.x"
+          python-version: "3.10.x"
           architecture: "x64"
 
       - name: Install tox
@@ -204,7 +204,7 @@ jobs:
     steps:
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.8.x"
+          python-version: "3.10.x"
           architecture: "x64"
       - name: Install SQL Server
         uses: Particular/install-sql-server-action@v1.2.0
@@ -246,7 +246,7 @@ jobs:
     steps:
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.8.x"
+          python-version: "3.10.x"
           architecture: "x64"
       - name: Install SQL Server
         uses: Particular/install-sql-server-action@v1.2.0

--- a/.github/workflows/ci_test_package.yml
+++ b/.github/workflows/ci_test_package.yml
@@ -239,10 +239,9 @@ jobs:
       matrix:
         # When supporting a new version, update the list here
         version: ["1_3_0", "1_4_0", "1_7_0", "1_8_0"]
-        run: tox -e integration_sqlserver_${{ matrix.version }}
-        runs-on: ubuntu-latest
-        environment:
-          name: Approve Integration Tests
+    runs-on: ubuntu-latest
+    environment:
+      name: Approve Integration Tests
 
     steps:
       - uses: actions/setup-python@v4

--- a/.github/workflows/main_test_package.yml
+++ b/.github/workflows/main_test_package.yml
@@ -60,7 +60,7 @@ jobs:
 
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.8.x"
+          python-version: "3.9.x"
           architecture: "x64"
 
       - name: Install tox
@@ -116,7 +116,7 @@ jobs:
     steps:
     - uses: actions/setup-python@v4
       with:
-        python-version: "3.8.x"
+        python-version: "3.9.x"
         architecture: "x64"
     - name: Install SQL Server
       uses: Particular/install-sql-server-action@v1.2.0


### PR DESCRIPTION
## Overview
Updates the indentation for `single-run-different-versions` step for `sqlserver`. The yml indentation put the `runs-on` and `environment` properties under `strategy`, when they should be inline with that property.

## Update type - breaking / non-breaking

<!-- What type of update is this? -->
- [X] Minor bug fix
- [ ] Documentation improvements
- [ ] Quality of Life improvements
- [ ] New features (non-breaking change)
- [ ] New features (breaking change)
- [ ] Other (non-breaking change)
- [ ] Other (breaking change)
- [ ] Release preparation

## What does this solve?
Should solve CI issues once merged

## Outstanding questions

<!-- Include any details here of issues you found along the way, or things that still require attention -->

## What databases have you tested with?

<!-- You don't need to have tested with them all, but this helps us know which you have tried already -->
- [ ] Snowflake
- [ ] Google BigQuery
- [ ] Databricks
- [ ] Spark
- [ ] N/A
