### PR TITLE
Remove orphaned `endmacro` block in `macros/upload_results/insert_into_metadata_table.sql`

### DIFF
--- a/macros/upload_results/insert_into_metadata_table.sql
+++ b/macros/upload_results/insert_into_metadata_table.sql
@@ -45,8 +45,6 @@
 
 {%- endmacro %}
 
-{%- endmacro %}
-
 {% macro postgres__insert_into_metadata_table(relation, fields, content) -%}
 
     {% set insert_into_table_query %}


### PR DESCRIPTION
## Overview

For a long time dbt-core has ignored extraneous/orphaned block tags. However, in 1.10 we're going to start issuing a deprecation warning for them. As such, it made sense to get this cleaned up :)


## Update type - breaking / non-breaking

<!-- What type of update is this? -->
- [X] Minor bug fix
- [ ] Documentation improvements
- [ ] Quality of Life improvements
- [ ] New features (non-breaking change)
- [ ] New features (breaking change)
- [ ] Other (non-breaking change)
- [ ] Other (breaking change)
- [ ] Release preparation

## What does this solve?

Ensuring dbt-core doesn't emit deprecation warnings due to a dangling `endmacro` block 🙂 

## Outstanding questions

<!-- Include any details here of issues you found along the way, or things that still require attention -->
N/A

## What databases have you tested with?

<!-- You don't need to have tested with them all, but this helps us know which you have tried already -->
- [ ] Snowflake
- [ ] Google BigQuery
- [ ] Databricks
- [ ] Spark
- [X] N/A
