### PR TITLE
Update insert_into_metadata_table.sql

### DIFF
--- a/macros/upload_results/insert_into_metadata_table.sql
+++ b/macros/upload_results/insert_into_metadata_table.sql
@@ -45,8 +45,6 @@
 
 {%- endmacro %}
 
-{%- endmacro %}
-
 {% macro postgres__insert_into_metadata_table(relation, fields, content) -%}
 
     {% set insert_into_table_query %}


### PR DESCRIPTION



## Overview

Remove redundant `endmacro` tag.

## Update type - breaking / non-breaking

<!-- What type of update is this? -->
- [x] Minor bug fix
- [ ] Documentation improvements
- [ ] Quality of Life improvements
- [ ] New features (non-breaking change)
- [ ] New features (breaking change)
- [ ] Other (non-breaking change)
- [ ] Other (breaking change)
- [ ] Release preparation

## What does this solve?

dbt parse was failing because of the tag error in the macro.

## Outstanding questions

<!-- Include any details here of issues you found along the way, or things that still require attention -->

## What databases have you tested with?

<!-- You don't need to have tested with them all, but this helps us know which you have tried already -->
- [x] Snowflake
- [ ] Google BigQuery
- [ ] Databricks
- [ ] Spark
- [ ] N/A
