### PR TITLE
fix: Removed an obsolete endmacro statement

### DIFF
--- a/macros/upload_results/insert_into_metadata_table.sql
+++ b/macros/upload_results/insert_into_metadata_table.sql
@@ -45,8 +45,6 @@
 
 {%- endmacro %}
 
-{%- endmacro %}
-
 {% macro postgres__insert_into_metadata_table(relation, fields, content) -%}
 
     {% set insert_into_table_query %}


### PR DESCRIPTION

## Overview

<!-- In 1-2 sentences, provide an overview of what this PR does -->
Fixed an issue in insert_into_metadata_table.sql by removing an unexpected and obsolete endmacro statement that was causing dbt deprecation warnings.
## Update type - breaking / non-breaking

<!-- What type of update is this? -->
- [x] Minor bug fix
- [ ] Documentation improvements
- [ ] Quality of Life improvements
- [ ] New features (non-breaking change)
- [ ] New features (breaking change)
- [ ] Other (non-breaking change)
- [ ] Other (breaking change)
- [ ] Release preparation

## What does this solve?

<!-- Include any links to relevant open issues -->
This PR fixes the dbt deprecation warning: "Found unexpected 'endmacro' block tag" that appeared when running dbt commands. The warning was occurring due to an extra, unnecessary endmacro tag in macros/upload_results/insert_into_metadata_table.sql file.
## Outstanding questions
None. This is a straightforward fix to remove syntax that was causing a warning.
<!-- Include any details here of issues you found along the way, or things that still require attention -->

## What databases have you tested with?

<!-- You don't need to have tested with them all, but this helps us know which you have tried already -->
- [x] Snowflake
- [ ] Google BigQuery
- [ ] Databricks
- [ ] Spark
- [ ] N/A
