### PR TITLE
Add tweaks/clarifications for MAINTAINERS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,8 @@ If you are able to implement the feature, please [open a pull request](https://g
 your changes. If you need help with either of these steps, please let us know!
 
 ## New Contributor Guide
-- To get an overview of the project, read the [README](https://github.com/brooklyn-data/dbt_artifacts/blob/main/README.md) file.
+- To get an overview of the project, read our [README](README.md).
+- There's a fair bit of infrastructure to set up for integration testing, read more in [MAINTAINERS.md](docs/MAINTAINERS.md)
 - Look for [issues](https://github.com/brooklyn-data/dbt_artifacts/issues) labeled as "good first issue" - these are issues which would be good for newcomers.
 
 ## Contributing Code :computer:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This package builds a mart of tables and views describing the project it is inst
 
 ## Contributing
 
-Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for more information.
+Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) and [MAINTAINERS.md](docs/MAINTAINERS.md) for more information.
 
 ## Supported Data Warehouses
 

--- a/docs/MAINTAINERS.md
+++ b/docs/MAINTAINERS.md
@@ -1,5 +1,9 @@
 # Contributing to the dbt Artifacts Package as a Maintainer
 
+> [!IMPORTANT]
+> This guide was written for Brooklyn Data engineers and contains details that are specific to the Brooklyn Data workplace (i.e., Slack channel names), but much of this
+> will be useful for all contributors, internal or external to Brooklyn Data. 
+
 ## General Guidance
 - You can create your own branches in the repo - no need to fork. Make sure to ask in the #_dbt_artifacts Slack channel
   if you need to be given permissions to contribute.


### PR DESCRIPTION
## Overview

Tiny tweaks to improve discoverability of the MAINTAINERS.md file but also call out that it was written for BDC engineers. I tested the links to make sure they pointed to the right places

## Update type - breaking / non-breaking

<!-- What type of update is this? -->
- [ ] Minor bug fix
- [x] Documentation improvements
- [ ] Quality of Life improvements
- [ ] New features (non-breaking change)
- [ ] New features (breaking change)
- [ ] Other (non-breaking change)
- [ ] Other (breaking change)
- [ ] Release preparation

