### PR TITLE
[FIX] Pin ubuntu version for sql server

### DIFF
--- a/.github/workflows/ci_test_package.yml
+++ b/.github/workflows/ci_test_package.yml
@@ -207,7 +207,7 @@ jobs:
   integration-sqlserver:
     strategy:
       fail-fast: false # Don't fail one DWH if the others fail
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     environment:
       name: Approve Integration Tests
 
@@ -249,7 +249,7 @@ jobs:
       matrix:
         # When supporting a new version, update the list here
         version: ["1_3_0", "1_4_0", "1_7_0", "1_8_0"]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     environment:
       name: Approve Integration Tests
 

--- a/.github/workflows/main_test_package.yml
+++ b/.github/workflows/main_test_package.yml
@@ -114,7 +114,7 @@ jobs:
       matrix:
         # When supporting a new version, update the list here
         version: ["1_3_0", "1_4_0", "1_7_0", "1_8_0"]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     environment:
       name: Approve Integration Tests
 


### PR DESCRIPTION
## Overview
CI and main integration testing failing for SQL server, which is most likely due to the most recent version of ubunto removing certain packages
- https://github.com/actions/runner-images/issues/10636
- https://github.com/Particular/install-sql-server-action/issues/21

This PR pins the SQL Server integration tests workflows to use ubunto-22.04

## Update type - breaking / non-breaking

<!-- What type of update is this? -->
- [ ] Minor bug fix
- [ ] Documentation improvements
- [x] Quality of Life improvements
- [ ] New features (non-breaking change)
- [ ] New features (breaking change)
- [x] Other (non-breaking change)
- [ ] Other (breaking change)
- [ ] Release preparation

## What does this solve?

<!-- Include any links to relevant open issues -->

## Outstanding questions

<!-- Include any details here of issues you found along the way, or things that still require attention -->

## What databases have you tested with?

<!-- You don't need to have tested with them all, but this helps us know which you have tried already -->
- [ ] Snowflake
- [ ] Google BigQuery
- [ ] Databricks
- [ ] Spark
- [ ] N/A
