### PR TITLE
make package compatible with Azure Synapse and Microsoft Fabric

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -18,6 +18,6 @@ models:
       +full_refresh: false
       +persist_docs:
         # Databricks and SQL Server don't offer column-level support for persisting docs
-        columns: '{{ target.name != "databricks" and target.type != "sqlserver" }}'
-        relation: '{{ target.type != "sqlserver" }}'
+        columns: '{{ target.name != "databricks" and target.type != "sqlserver" and target.type != "synapse" and target.type != "fabric" }}'
+        relation: '{{ target.type != "sqlserver" and target.type != "synapse" and target.type != "fabric" }}'
       +as_columnstore: False

--- a/integration_test_project/seeds/seeds.yml
+++ b/integration_test_project/seeds/seeds.yml
@@ -5,4 +5,4 @@ seeds:
     config:
       column_types:
         id: integer
-        load_timestamp: "{{ 'datetime2' if target.type == 'sqlserver' else 'timestamp' }}"
+        load_timestamp: "{{ 'datetime2' if target.type == 'sqlserver' or target.type == 'synapse' or target.type == 'fabric' else 'timestamp' }}"

--- a/macros/database_specific_helpers/type_helpers.sql
+++ b/macros/database_specific_helpers/type_helpers.sql
@@ -26,6 +26,10 @@
    json
 {% endmacro %}
 
+{% macro fabric__type_json() %}
+   varchar(max)
+{% endmacro %}
+
 {#- ARRAY -#}
 
 {% macro type_array() %}
@@ -46,6 +50,10 @@
 
 {% macro trino__type_array() %}
    array(varchar)
+{% endmacro %}
+
+{% macro fabric__type_array() %}
+   varchar(max)
 {% endmacro %}
 
 {#- NUMERIC -#}%}

--- a/macros/integration_tests/safe_cast.sql
+++ b/macros/integration_tests/safe_cast.sql
@@ -5,6 +5,8 @@
     'string': {
       'postgres': 'TEXT',
       'sqlserver': 'VARCHAR',
+      'synapse': 'VARCHAR',
+      'fabric': 'VARCHAR',
       'bigquery': 'STRING',
       'snowflake': 'VARCHAR',
       'databricks': 'STRING',
@@ -13,6 +15,8 @@
     'integer': {
       'postgres': 'NUMERIC',
       'sqlserver': 'FLOAT',
+      'synapse': 'FLOAT',
+      'fabric': 'FLOAT',
       'bigquery': 'FLOAT64',
       'snowflake': 'FLOAT',
       'databricks': 'DOUBLE',
@@ -21,6 +25,8 @@
     'date': {
       'postgres': 'DATE',
       'sqlserver': 'DATE',
+      'synapse': 'DATE',
+      'fabric': 'DATE',
       'bigquery': 'DATE',
       'snowflake': 'DATE',
       'databricks': 'DATE',
@@ -29,6 +35,8 @@
     'timestamp': {
       'postgres': 'TIMESTAMP',
       'sqlserver': 'DATETIME2',
+      'synapse': 'DATETIME2',
+      'fabric': 'DATETIME2',
       'bigquery': 'TIMESTAMP',
       'snowflake': 'TIMESTAMP',
       'databricks': 'TIMESTAMP',

--- a/macros/upload_individual_datasets/upload_exposures.sql
+++ b/macros/upload_individual_datasets/upload_exposures.sql
@@ -116,7 +116,7 @@
     {% endif %}
 {%- endmacro %}
 
-{% macro sqlserver__get_exposures_dml_sql(exposures) -%}
+{% macro fabric__get_exposures_dml_sql(exposures) -%}
 
     {% if exposures != [] %}
         {% set exposure_values %}

--- a/macros/upload_individual_datasets/upload_invocations.sql
+++ b/macros/upload_individual_datasets/upload_invocations.sql
@@ -298,7 +298,7 @@
 {% endmacro -%}
 
 
-{% macro sqlserver__get_invocations_dml_sql() -%}
+{% macro fabric__get_invocations_dml_sql() -%}
     {% set invocation_values %}
     select
         "1",

--- a/macros/upload_individual_datasets/upload_invocations.sql
+++ b/macros/upload_individual_datasets/upload_invocations.sql
@@ -283,7 +283,7 @@
 {% endmacro -%}
 
 
-{% macro sqlserver__get_invocations_dml_sql(invocation_args=invocation_args_dict) -%}
+{% macro fabric__get_invocations_dml_sql(invocation_args=invocation_args_dict) -%}
     {% set invocation_values %}
     select
         "1",

--- a/macros/upload_individual_datasets/upload_model_executions.sql
+++ b/macros/upload_individual_datasets/upload_model_executions.sql
@@ -201,7 +201,7 @@
 {%- endmacro %}
 
 
-{% macro sqlserver__get_model_executions_dml_sql(models) -%}
+{% macro fabric__get_model_executions_dml_sql(models) -%}
     {% if models != [] %}
         {% set model_execution_values %}
         select

--- a/macros/upload_individual_datasets/upload_models.sql
+++ b/macros/upload_individual_datasets/upload_models.sql
@@ -123,7 +123,7 @@
 {%- endmacro %}
 
 
-{% macro sqlserver__get_models_dml_sql(models) -%}
+{% macro fabric__get_models_dml_sql(models) -%}
 
     {% if models != [] %}
         {% set model_values %}

--- a/macros/upload_individual_datasets/upload_models.sql
+++ b/macros/upload_individual_datasets/upload_models.sql
@@ -126,7 +126,7 @@
 {%- endmacro %}
 
 
-{% macro sqlserver__get_models_dml_sql(models) -%}
+{% macro fabric__get_models_dml_sql(models) -%}
 
     {% if models != [] %}
         {% set model_values %}

--- a/macros/upload_individual_datasets/upload_seed_executions.sql
+++ b/macros/upload_individual_datasets/upload_seed_executions.sql
@@ -214,7 +214,7 @@
     {% endif %}
 {% endmacro -%}
 
-{% macro sqlserver__get_seed_executions_dml_sql(seeds) -%}
+{% macro fabric__get_seed_executions_dml_sql(seeds) -%}
     {% if seeds != [] %}
         {% set seed_execution_values %}
         select

--- a/macros/upload_individual_datasets/upload_seeds.sql
+++ b/macros/upload_individual_datasets/upload_seeds.sql
@@ -107,7 +107,7 @@
     {% endif %}
 {%- endmacro %}
 
-{% macro sqlserver__get_seeds_dml_sql(seeds) -%}
+{% macro fabric__get_seeds_dml_sql(seeds) -%}
 
     {% if seeds != [] %}
         {% set seed_values %}

--- a/macros/upload_individual_datasets/upload_snapshot_executions.sql
+++ b/macros/upload_individual_datasets/upload_snapshot_executions.sql
@@ -214,7 +214,7 @@
     {% endif %}
 {% endmacro -%}
 
-{% macro sqlserver__get_snapshot_executions_dml_sql(snapshots) -%}
+{% macro fabric__get_snapshot_executions_dml_sql(snapshots) -%}
     {% if snapshots != [] %}
         {% set snapshot_execution_values %}
         select

--- a/macros/upload_individual_datasets/upload_snapshots.sql
+++ b/macros/upload_individual_datasets/upload_snapshots.sql
@@ -118,7 +118,7 @@
 {%- endmacro %}
 
 
-{% macro sqlserver__get_snapshots_dml_sql(snapshots) -%}
+{% macro fabric__get_snapshots_dml_sql(snapshots) -%}
 
     {% if snapshots != [] %}
         {% set snapshot_values %}

--- a/macros/upload_individual_datasets/upload_sources.sql
+++ b/macros/upload_individual_datasets/upload_sources.sql
@@ -108,7 +108,7 @@
 {%- endmacro %}
 
 
-{% macro sqlserver__get_sources_dml_sql(sources) -%}
+{% macro fabric__get_sources_dml_sql(sources) -%}
 
     {% if sources != [] %}
         {% set source_values %}

--- a/macros/upload_individual_datasets/upload_test_executions.sql
+++ b/macros/upload_individual_datasets/upload_test_executions.sql
@@ -198,7 +198,7 @@
     {% endif %}
 {% endmacro -%}
 
-{% macro sqlserver__get_test_executions_dml_sql(tests) -%}
+{% macro fabric__get_test_executions_dml_sql(tests) -%}
     {% if tests != [] %}
         {% set test_execution_values %}
         select

--- a/macros/upload_individual_datasets/upload_tests.sql
+++ b/macros/upload_individual_datasets/upload_tests.sql
@@ -96,7 +96,7 @@
 {%- endmacro %}
 
 
-{% macro sqlserver__get_tests_dml_sql(tests) -%}
+{% macro fabric__get_tests_dml_sql(tests) -%}
 
     {% if tests != [] %}
         {% set test_values %}

--- a/macros/upload_results/get_column_name_lists.sql
+++ b/macros/upload_results/get_column_name_lists.sql
@@ -63,7 +63,7 @@
             {% if target.type == "bigquery" %} bytes_processed,
             {% endif %}
             materialization,
-            {% if target.type == "sqlserver" %} "schema",
+            {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} "schema",
             {% else %} schema,
             {% endif %}
             name,
@@ -78,7 +78,7 @@
             command_invocation_id,
             node_id,
             run_started_at,
-            {% if target.type == "sqlserver" %} "database", "schema",
+            {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} "database", "schema",
             {% else %} database, schema,
             {% endif %}
             name,
@@ -107,7 +107,7 @@
             total_node_runtime,
             rows_affected,
             materialization,
-            {% if target.type == "sqlserver" %} "schema",
+            {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} "schema",
             {% else %} schema,
             {% endif %}
             name,
@@ -122,7 +122,7 @@
             command_invocation_id,
             node_id,
             run_started_at,
-            {% if target.type == "sqlserver" %} "database", "schema",
+            {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} "database", "schema",
             {% else %} database, schema,
             {% endif %}
             name,
@@ -148,7 +148,7 @@
             total_node_runtime,
             rows_affected,
             materialization,
-            {% if target.type == "sqlserver" %} "schema",
+            {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} "schema",
             {% else %} schema,
             {% endif %}
             name,
@@ -163,7 +163,7 @@
             command_invocation_id,
             node_id,
             run_started_at,
-            {% if target.type == "sqlserver" %} "database", "schema",
+            {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} "database", "schema",
             {% else %} database, schema,
             {% endif %}
             name,
@@ -183,7 +183,7 @@
             command_invocation_id,
             node_id,
             run_started_at,
-            {% if target.type == "sqlserver" %} "database", "schema",
+            {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} "database", "schema",
             {% else %} database, schema,
             {% endif %}
             source_name,

--- a/macros/upload_results/insert_into_metadata_table.sql
+++ b/macros/upload_results/insert_into_metadata_table.sql
@@ -57,7 +57,7 @@
 
 {%- endmacro %}
 
-{% macro sqlserver__insert_into_metadata_table(relation, fields, content) -%}
+{% macro fabric__insert_into_metadata_table(relation, fields, content) -%}
 
     {% set insert_into_table_query %}
     insert into {{ relation }} {{ fields }}

--- a/models/dim_dbt__current_models.sql
+++ b/models/dim_dbt__current_models.sql
@@ -40,19 +40,19 @@ with
             node_id,
             max(
                 case
-                    when was_full_refresh {% if target.type == "sqlserver" %} = 1 {% endif %}
+                    when was_full_refresh {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} = 1 {% endif %}
                     then query_completed_at
                 end
             ) as last_full_refresh_run_completed_at,
             max(
                 case
-                    when was_full_refresh {% if target.type == "sqlserver" %} = 1 {% endif %}
+                    when was_full_refresh {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} = 1 {% endif %}
                     then total_node_runtime
                 end
             ) as last_full_refresh_run_total_runtime,
             max(
                 case
-                    when was_full_refresh {% if target.type == "sqlserver" %} = 1 {% endif %}
+                    when was_full_refresh {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} = 1 {% endif %}
                     then rows_affected
                 end
             ) as last_full_refresh_run_rows_affected
@@ -75,19 +75,19 @@ with
             {% endif %},
             max(
                 case
-                    when not was_full_refresh {% if target.type == "sqlserver" %} = 1 {% endif %}
+                    when not was_full_refresh {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} = 1 {% endif %}
                     then query_completed_at
                 end
             ) as last_incremental_run_completed_at,
             max(
                 case
-                    when not was_full_refresh {% if target.type == "sqlserver" %} = 1 {% endif %}
+                    when not was_full_refresh {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} = 1 {% endif %}
                     then total_node_runtime
                 end
             ) as last_incremental_run_total_runtime,
             max(
                 case
-                    when not was_full_refresh {% if target.type == "sqlserver" %} = 1 {% endif %}
+                    when not was_full_refresh {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} = 1 {% endif %}
                     then rows_affected
                 end
             ) as last_incremental_run_rows_affected

--- a/models/dim_dbt__models.sql
+++ b/models/dim_dbt__models.sql
@@ -9,10 +9,10 @@ with
             node_id,
             run_started_at,
             name,
-            {% if target.type == "sqlserver" %} "database"
+            {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} "database"
             {% else %} database
             {% endif %},
-            {% if target.type == "sqlserver" %} "schema"
+            {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} "schema"
             {% else %} schema
             {% endif %},
             depends_on_nodes,

--- a/models/dim_dbt__seeds.sql
+++ b/models/dim_dbt__seeds.sql
@@ -9,10 +9,10 @@ with
             node_id,
             run_started_at,
             name,
-            {% if target.type == "sqlserver" %} "database"
+            {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} "database"
             {% else %} database
             {% endif %},
-            {% if target.type == "sqlserver" %} "schema"
+            {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} "schema"
             {% else %} schema
             {% endif %},
             package_name,

--- a/models/dim_dbt__snapshots.sql
+++ b/models/dim_dbt__snapshots.sql
@@ -9,10 +9,10 @@ with
             node_id,
             run_started_at,
             name,
-            {% if target.type == "sqlserver" %} "database"
+            {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} "database"
             {% else %} database
             {% endif %},
-            {% if target.type == "sqlserver" %} "schema"
+            {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} "schema"
             {% else %} schema
             {% endif %},
             depends_on_nodes,

--- a/models/dim_dbt__sources.sql
+++ b/models/dim_dbt__sources.sql
@@ -8,10 +8,10 @@ with
             command_invocation_id,
             node_id,
             run_started_at,
-            {% if target.type == "sqlserver" %} "database"
+            {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} "database"
             {% else %} database
             {% endif %},
-            {% if target.type == "sqlserver" %} "schema"
+            {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} "schema"
             {% else %} schema
             {% endif %},
             source_name,

--- a/models/fct_dbt__model_executions.sql
+++ b/models/fct_dbt__model_executions.sql
@@ -17,7 +17,7 @@ with
             rows_affected
             {% if target.type == "bigquery" %}, bytes_processed {% endif %},
             materialization,
-            {% if target.type == "sqlserver" %} "schema"
+            {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} "schema"
             {% else %} schema
             {% endif %},
             name,

--- a/models/fct_dbt__seed_executions.sql
+++ b/models/fct_dbt__seed_executions.sql
@@ -16,7 +16,7 @@ with
             total_node_runtime,
             rows_affected,
             materialization,
-            {% if target.type == "sqlserver" %} "schema"
+            {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} "schema"
             {% else %} schema
             {% endif %},
             name,

--- a/models/fct_dbt__snapshot_executions.sql
+++ b/models/fct_dbt__snapshot_executions.sql
@@ -16,7 +16,7 @@ with
             total_node_runtime,
             rows_affected,
             materialization,
-            {% if target.type == "sqlserver" %} "schema"
+            {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} "schema"
             {% else %} schema
             {% endif %},
             name,

--- a/models/sources/model_executions.sql
+++ b/models/sources/model_executions.sql
@@ -16,7 +16,7 @@ select
         cast(null as {{ type_int() }}) as bytes_processed,
     {% endif %}
     cast(null as {{ type_string() }}) as materialization,
-    cast(null as {{ type_string() }}) as {% if target.type == "sqlserver" %} "schema"
+    cast(null as {{ type_string() }}) as {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} "schema"
     {% else %} schema
     {% endif %},
     cast(null as {{ type_string() }}) as name,

--- a/models/sources/models.sql
+++ b/models/sources/models.sql
@@ -5,10 +5,10 @@ select
     cast(null as {{ type_string() }}) as command_invocation_id,
     cast(null as {{ type_string() }}) as node_id,
     cast(null as {{ type_timestamp() }}) as run_started_at,
-    cast(null as {{ type_string() }}) as {% if target.type == "sqlserver" %} "database"
+    cast(null as {{ type_string() }}) as {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} "database"
     {% else %} database
     {% endif %},
-    cast(null as {{ type_string() }}) as {% if target.type == "sqlserver" %} "schema"
+    cast(null as {{ type_string() }}) as {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} "schema"
     {% else %} schema
     {% endif %},
     cast(null as {{ type_string() }}) as name,

--- a/models/sources/seed_executions.sql
+++ b/models/sources/seed_executions.sql
@@ -13,7 +13,7 @@ select
     cast(null as {{ type_float() }}) as total_node_runtime,
     cast(null as {{ type_int() }}) as rows_affected,
     cast(null as {{ type_string() }}) as materialization,
-    cast(null as {{ type_string() }}) as {% if target.type == "sqlserver" %} "schema"
+    cast(null as {{ type_string() }}) as {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} "schema"
     {% else %} schema
     {% endif %},
     cast(null as {{ type_string() }}) as name,

--- a/models/sources/seeds.sql
+++ b/models/sources/seeds.sql
@@ -5,10 +5,10 @@ select
     cast(null as {{ type_string() }}) as command_invocation_id,
     cast(null as {{ type_string() }}) as node_id,
     cast(null as {{ type_timestamp() }}) as run_started_at,
-    cast(null as {{ type_string() }}) as {% if target.type == "sqlserver" %} "database"
+    cast(null as {{ type_string() }}) as {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} "database"
     {% else %} database
     {% endif %},
-    cast(null as {{ type_string() }}) as {% if target.type == "sqlserver" %} "schema"
+    cast(null as {{ type_string() }}) as {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} "schema"
     {% else %} schema
     {% endif %},
     cast(null as {{ type_string() }}) as name,

--- a/models/sources/snapshot_executions.sql
+++ b/models/sources/snapshot_executions.sql
@@ -13,7 +13,7 @@ select
     cast(null as {{ type_float() }}) as total_node_runtime,
     cast(null as {{ type_int() }}) as rows_affected,
     cast(null as {{ type_string() }}) as materialization,
-    cast(null as {{ type_string() }}) as {% if target.type == "sqlserver" %} "schema"
+    cast(null as {{ type_string() }}) as {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} "schema"
     {% else %} schema
     {% endif %},
     cast(null as {{ type_string() }}) as name,

--- a/models/sources/snapshots.sql
+++ b/models/sources/snapshots.sql
@@ -5,10 +5,10 @@ select
     cast(null as {{ type_string() }}) as command_invocation_id,
     cast(null as {{ type_string() }}) as node_id,
     cast(null as {{ type_timestamp() }}) as run_started_at,
-    cast(null as {{ type_string() }}) as {% if target.type == "sqlserver" %} "database"
+    cast(null as {{ type_string() }}) as {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} "database"
     {% else %} database
     {% endif %},
-    cast(null as {{ type_string() }}) as {% if target.type == "sqlserver" %} "schema"
+    cast(null as {{ type_string() }}) as {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} "schema"
     {% else %} schema
     {% endif %},
     cast(null as {{ type_string() }}) as name,

--- a/models/sources/sources.sql
+++ b/models/sources/sources.sql
@@ -5,10 +5,10 @@ select
     cast(null as {{ type_string() }}) as command_invocation_id,
     cast(null as {{ type_string() }}) as node_id,
     cast(null as {{ type_timestamp() }}) as run_started_at,
-    cast(null as {{ type_string() }}) as {% if target.type == "sqlserver" %} "database"
+    cast(null as {{ type_string() }}) as {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} "database"
     {% else %} database
     {% endif %},
-    cast(null as {{ type_string() }}) as {% if target.type == "sqlserver" %} "schema"
+    cast(null as {{ type_string() }}) as {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} "schema"
     {% else %} schema
     {% endif %},
     cast(null as {{ type_string() }}) as source_name,

--- a/models/staging/stg_dbt__model_executions.sql
+++ b/models/staging/stg_dbt__model_executions.sql
@@ -17,7 +17,7 @@ with
             rows_affected
             {% if target.type == "bigquery" %}, bytes_processed {% endif %},
             materialization,
-            {% if target.type == "sqlserver" %} "schema"
+            {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} "schema"
             {% else %} schema
             {% endif %},  -- noqa
             name,

--- a/models/staging/stg_dbt__models.sql
+++ b/models/staging/stg_dbt__models.sql
@@ -8,10 +8,10 @@ with
             command_invocation_id,
             node_id,
             run_started_at,
-            {% if target.type == "sqlserver" %} "database"
+            {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} "database"
             {% else %} database
             {% endif %},
-            {% if target.type == "sqlserver" %} "schema"
+            {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} "schema"
             {% else %} schema
             {% endif %},  -- noqa
             name,

--- a/models/staging/stg_dbt__seed_executions.sql
+++ b/models/staging/stg_dbt__seed_executions.sql
@@ -16,7 +16,7 @@ with
             total_node_runtime,
             rows_affected,
             materialization,
-            {% if target.type == "sqlserver" %} "schema"
+            {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} "schema"
             {% else %} schema
             {% endif %},  -- noqa
             name,

--- a/models/staging/stg_dbt__seeds.sql
+++ b/models/staging/stg_dbt__seeds.sql
@@ -8,10 +8,10 @@ with
             command_invocation_id,
             node_id,
             run_started_at,
-            {% if target.type == "sqlserver" %} "database"
+            {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} "database"
             {% else %} database
             {% endif %},
-            {% if target.type == "sqlserver" %} "schema"
+            {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} "schema"
             {% else %} schema
             {% endif %},
             name,

--- a/models/staging/stg_dbt__snapshot_executions.sql
+++ b/models/staging/stg_dbt__snapshot_executions.sql
@@ -16,7 +16,7 @@ with
             total_node_runtime,
             rows_affected,
             materialization,
-            {% if target.type == "sqlserver" %} "schema"
+            {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} "schema"
             {% else %} schema
             {% endif %},  -- noqa
             name,

--- a/models/staging/stg_dbt__snapshots.sql
+++ b/models/staging/stg_dbt__snapshots.sql
@@ -9,10 +9,10 @@ with
             command_invocation_id,
             node_id,
             run_started_at,
-            {% if target.type == "sqlserver" %} "database"
+            {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} "database"
             {% else %} database
             {% endif %},
-            {% if target.type == "sqlserver" %} "schema"
+            {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} "schema"
             {% else %} schema
             {% endif %},
             name,

--- a/models/staging/stg_dbt__sources.sql
+++ b/models/staging/stg_dbt__sources.sql
@@ -8,10 +8,10 @@ with
             command_invocation_id,
             node_id,
             run_started_at,
-            {% if target.type == "sqlserver" %} "database"
+            {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} "database"
             {% else %} database
             {% endif %},
-            {% if target.type == "sqlserver" %} "schema"
+            {% if target.type == "sqlserver" or target.type == "synapse" or target.type == "fabric" %} "schema"
             {% else %} schema
             {% endif %},
             source_name,


### PR DESCRIPTION
## Overview

This adds compatibility for Azure Synapse and Microsoft Fabric.

The new version of the sqlserver adapter inherits from the fabric adapter. So in the macros, we can replace `sqlserver__` with `fabric__`.

### Changes

- Rename all `sqlserver__` dispatch macros to `fabric__` (sqlserver inherits from fabric, so dispatch finds these via the adapter type hierarchy)
- Add `fabric__type_json()` and `fabric__type_array()` returning `varchar(max)` — fixes #521 (truncation errors from `varchar(8000)`)
- Update all `target.type` conditionals to include `"synapse"` and `"fabric"` alongside `"sqlserver"`
- Add Fabric/Synapse type mappings in integration test helpers

## Update type - breaking / non-breaking

- [x] New features (non-breaking change)

## What does this solve?

- Adds native compatibility for Microsoft Fabric and Azure Synapse adapters
- Fixes #521 — JSON/array columns were created as `varchar(8000)` instead of `varchar(max)`, causing truncation when uploading large payloads
- Addresses #533 — native Fabric compatibility request

## What databases have you tested with?

- [x] Microsoft Fabric (Data Warehouse)