### PR TITLE
Update package to show Fusion compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 target/
 dbt_modules/
 dbt_packages/
+dbt_internal_packages/
 logs/
 
 .vscode/

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,7 +1,7 @@
 name: "dbt_artifacts"
 version: "2.9.3"
 config-version: 2
-require-dbt-version: [">=1.3.0", "<1.11.0"]
+require-dbt-version: [">=1.3.0", "<3.0.0"]
 profile: "dbt_artifacts"
 
 clean-targets: # folders to be removed by `dbt clean`

--- a/integration_test_project/dbt_project.yml
+++ b/integration_test_project/dbt_project.yml
@@ -10,16 +10,13 @@ test-paths: ["tests"]
 seed-paths: ["seeds"]
 macro-paths: ["macros"]
 snapshot-paths: ["snapshots"]
-
-target-path: "target"
 clean-targets: ["target", "dbt_packages"]
 
 vars:
   test_dbt_vars_1: dbt_vars_1
   test_dbt_vars_2: dbt_vars_2
   test_dbt_vars_3: dbt_vars_3
-  env_vars:
-    ["TEST_ENV_VAR_NUMBER", "TEST_ENV_VAR_EMPTY", "TEST_ENV_VAR_WITH_QUOTE"]
+  env_vars: ["TEST_ENV_VAR_NUMBER", "TEST_ENV_VAR_EMPTY", "TEST_ENV_VAR_WITH_QUOTE"]
   dbt_vars: ["test_dbt_vars_1", "test_dbt_vars_2", "test_dbt_vars_3"]
   dbt_artifacts_exclude_all_results: true
 

--- a/integration_test_project/models/sources.yml
+++ b/integration_test_project/models/sources.yml
@@ -4,19 +4,21 @@ sources:
   - name: dummy_source
     database: "{% if target.type not in ('spark', 'databricks') %}{{ var('dbt_artifacts_database', target.database) }}{% endif %}"
     schema: "{{ target.schema }}"
-    freshness:
-      error_after: {count: 24, period: hour}
-      filter: dayname(updatedat) not in ('Sunday', 'Monday')
-    loaded_at_field: convert_timezone('UTC', load_timestamp)
     tables:
       - name: doesnt_exist
       - name: '"GROUP"'
 
+    config:
+      freshness:
+        error_after: {count: 24, period: hour}
+        filter: dayname(updatedat) not in ('Sunday', 'Monday')
+      loaded_at_field: convert_timezone('UTC', load_timestamp)
   - name: freshness_check
     database: "{% if target.type not in ('spark', 'databricks') %}{{ var('dbt_artifacts_database', target.database) }}{% endif %}"
     schema: "{{ target.schema }}"
-    freshness:
-      error_after: {count: 1, period: hour}
-    loaded_at_field: load_timestamp
     tables:
       - name: freshness
+    config:
+      freshness:
+        error_after: {count: 1, period: hour}
+      loaded_at_field: load_timestamp

--- a/integration_test_project/models/tests_and_exposures.yml
+++ b/integration_test_project/models/tests_and_exposures.yml
@@ -15,7 +15,6 @@ exposures:
     maturity: high
     description: "ceo's favourite dashboard"
     url: https://bi.tool/dashboards/1
-    tags: ["ceo", "data"]
 
     depends_on:
       - ref('non_incremental')
@@ -24,12 +23,13 @@ exposures:
       name: Claire from Data
       email: data@jaffleshop.com
 
+    config:
+      tags: ["ceo", "data"]
   - name: cio_dashboard
     type: dashboard
     maturity: high
     description: '{{ doc("clickstream") }}'
     url: https://bi.tool/dashboards/1
-    tags: ["cio", "it"]
 
     depends_on:
       - ref('incremental')
@@ -37,3 +37,5 @@ exposures:
     owner:
       name: Henry from IT
       email: henry@jaffleshop.com
+    config:
+      tags: ["cio", "it"]


### PR DESCRIPTION
I tested the package on Fusion version preview-76 and it worked. 
It was failing at least until preview-72.

When preview-76 is the official latest (it is still canary as of now), we could get this merged and a new release could be pushed so that there is "official" support for Fusion.

We are working on showing in the dbt Hub the packages that have a `require-dbt-version` that contains the Fusion version (e.g. 2.x.y) so that we can highlight those easily.