### PR TITLE
Add duckdb support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ env.sh
 pyproject.toml
 
 .DS_Store
+*.duckdb

--- a/integration_test_project/models/microbatch.sql
+++ b/integration_test_project/models/microbatch.sql
@@ -10,7 +10,8 @@
         partition_by = {
             'field': 'store_name',
             'data_type': 'text',
-        }
+        },
+        tags = ['microbatch']
     )
 }}
 

--- a/integration_test_project/models/microbatch_transaction.sql
+++ b/integration_test_project/models/microbatch_transaction.sql
@@ -1,7 +1,8 @@
 {{
   config(
     materialized = 'table',
-    event_time = 'transaction_ts__hourly'
+    event_time = 'transaction_ts__hourly',
+    tags = ['microbatch']
     )
 }}
 

--- a/integration_test_project/models/microbatch_transaction_base.sql
+++ b/integration_test_project/models/microbatch_transaction_base.sql
@@ -1,6 +1,7 @@
 {{
   config(
     materialized = 'view',
+    tags = ['microbatch']
     )
 }}
 

--- a/integration_test_project/profiles.yml
+++ b/integration_test_project/profiles.yml
@@ -52,6 +52,10 @@ dbt_artifacts:
       dbname: postgres
       schema: public
       threads: 8
+    duckdb:
+      type: duckdb
+      path: "test.duckdb"
+      threads: 1
     sqlserver:
       type: sqlserver
       driver: 'ODBC Driver 18 for SQL Server'

--- a/macros/upload_individual_datasets/upload_exposures.sql
+++ b/macros/upload_individual_datasets/upload_exposures.sql
@@ -116,6 +116,11 @@
     {% endif %}
 {%- endmacro %}
 
+{% macro duckdb__get_exposures_dml_sql(exposures) -%}
+    {{ dbt_artifacts.postgres__get_exposures_dml_sql(exposures) }}
+{%- endmacro %}
+
+
 {% macro sqlserver__get_exposures_dml_sql(exposures) -%}
 
     {% if exposures != [] %}

--- a/macros/upload_individual_datasets/upload_invocations.sql
+++ b/macros/upload_individual_datasets/upload_invocations.sql
@@ -236,6 +236,10 @@
 
 {% endmacro -%}
 
+{% macro duckdb__get_invocations_dml_sql() -%}
+    {{ dbt_artifacts.postgres__get_invocations_dml_sql() }}
+{%- endmacro %}
+
 {% macro trino__get_invocations_dml_sql() -%}
     {% set invocation_values %}
         (

--- a/macros/upload_individual_datasets/upload_model_executions.sql
+++ b/macros/upload_individual_datasets/upload_model_executions.sql
@@ -200,6 +200,10 @@
     {% endif %}
 {%- endmacro %}
 
+{% macro duckdb__get_model_executions_dml_sql(models) -%}
+    {{ dbt_artifacts.postgres__get_model_executions_dml_sql(models) }}
+{%- endmacro %}
+
 
 {% macro sqlserver__get_model_executions_dml_sql(models) -%}
     {% if models != [] %}

--- a/macros/upload_individual_datasets/upload_models.sql
+++ b/macros/upload_individual_datasets/upload_models.sql
@@ -122,6 +122,9 @@
     {% endif %}
 {%- endmacro %}
 
+{% macro duckdb__get_models_dml_sql(models) -%}
+    {{ dbt_artifacts.postgres__get_models_dml_sql(models) }}
+{% endmacro %}
 
 {% macro sqlserver__get_models_dml_sql(models) -%}
 

--- a/macros/upload_individual_datasets/upload_seed_executions.sql
+++ b/macros/upload_individual_datasets/upload_seed_executions.sql
@@ -214,6 +214,10 @@
     {% endif %}
 {% endmacro -%}
 
+{% macro duckdb__get_seed_executions_dml_sql(seeds) -%}
+    {{ dbt_artifacts.postgres__get_seed_executions_dml_sql(seeds) }}
+{% endmacro %}
+
 {% macro sqlserver__get_seed_executions_dml_sql(seeds) -%}
     {% if seeds != [] %}
         {% set seed_execution_values %}

--- a/macros/upload_individual_datasets/upload_seeds.sql
+++ b/macros/upload_individual_datasets/upload_seeds.sql
@@ -107,6 +107,10 @@
     {% endif %}
 {%- endmacro %}
 
+{% macro duckdb__get_seeds_dml_sql(seeds) -%}
+    {{ dbt_artifacts.postgres__get_seeds_dml_sql(seeds) }}
+{% endmacro %}
+
 {% macro sqlserver__get_seeds_dml_sql(seeds) -%}
 
     {% if seeds != [] %}

--- a/macros/upload_individual_datasets/upload_snapshot_executions.sql
+++ b/macros/upload_individual_datasets/upload_snapshot_executions.sql
@@ -214,6 +214,10 @@
     {% endif %}
 {% endmacro -%}
 
+{% macro duckdb__get_snapshot_executions_dml_sql(snapshots) -%}
+    {{ dbt_artifacts.postgres__get_snapshot_executions_dml_sql(snapshots) }}
+{% endmacro -%}
+
 {% macro sqlserver__get_snapshot_executions_dml_sql(snapshots) -%}
     {% if snapshots != [] %}
         {% set snapshot_execution_values %}

--- a/macros/upload_individual_datasets/upload_snapshots.sql
+++ b/macros/upload_individual_datasets/upload_snapshots.sql
@@ -117,6 +117,9 @@
     {% endif %}
 {%- endmacro %}
 
+{% macro duckdb__get_snapshots_dml_sql(snapshots) -%}
+    {{ dbt_artifacts.postgres__get_snapshots_dml_sql(snapshots) }}
+{%- endmacro %}
 
 {% macro sqlserver__get_snapshots_dml_sql(snapshots) -%}
 

--- a/macros/upload_individual_datasets/upload_sources.sql
+++ b/macros/upload_individual_datasets/upload_sources.sql
@@ -107,6 +107,9 @@
     {% endif %}
 {%- endmacro %}
 
+{% macro duckdb__get_sources_dml_sql(sources) -%}
+    {{ dbt_artifacts.postgres__get_sources_dml_sql(sources) }}
+{%- endmacro %}
 
 {% macro sqlserver__get_sources_dml_sql(sources) -%}
 

--- a/macros/upload_individual_datasets/upload_test_executions.sql
+++ b/macros/upload_individual_datasets/upload_test_executions.sql
@@ -146,6 +146,11 @@
     {% endif %}
 {% endmacro -%}
 
+{% macro duckdb__get_test_executions_dml_sql(tests) -%}
+    {{ dbt_artifacts.postgres__get_test_executions_dml_sql(tests) }}
+{% endmacro -%}
+
+
 {% macro snowflake__get_test_executions_dml_sql(tests) -%}
     {% if tests != [] %}
         {% set test_execution_values %}

--- a/macros/upload_individual_datasets/upload_tests.sql
+++ b/macros/upload_individual_datasets/upload_tests.sql
@@ -95,6 +95,9 @@
     {% endif %}
 {%- endmacro %}
 
+{% macro duckdb__get_tests_dml_sql(tests) -%}
+    {{ dbt_artifacts.postgres__get_tests_dml_sql(tests) }}
+{% endmacro %}
 
 {% macro sqlserver__get_tests_dml_sql(tests) -%}
 

--- a/macros/upload_results/insert_into_metadata_table.sql
+++ b/macros/upload_results/insert_into_metadata_table.sql
@@ -57,6 +57,18 @@
 
 {%- endmacro %}
 
+{% macro duckdb__insert_into_metadata_table(relation, fields, content) -%}
+
+    {% set insert_into_table_query %}
+    insert into {{ relation }} {{ fields }}
+    values
+    {{ content }}
+    {% endset %}
+
+    {% do run_query(insert_into_table_query) %}
+
+{%- endmacro %}
+
 {% macro sqlserver__insert_into_metadata_table(relation, fields, content) -%}
 
     {% set insert_into_table_query %}

--- a/tox.ini
+++ b/tox.ini
@@ -391,6 +391,76 @@ commands =
     dbt deps
     dbt build --target postgres
 
+[testenv:integration_duckdb]
+changedir = integration_test_project
+deps =
+    dbt-core~=1.9.0
+    dbt-duckdb~=1.9.0
+commands =
+    dbt clean
+    dbt deps
+    dbt build --exclude tag:microbatch --target duckdb
+
+[testenv:integration_duckdb_1_3_0]
+changedir = integration_test_project
+deps = dbt-duckdb~=1.3.0
+commands =
+    dbt clean
+    dbt deps
+    dbt build --exclude tag:microbatch --target duckdb
+
+[testenv:integration_duckdb_1_4_0]
+changedir = integration_test_project
+deps = dbt-duckdb~=1.4.0
+commands =
+    dbt clean
+    dbt deps
+    dbt build --exclude tag:microbatch --target duckdb
+
+[testenv:integration_duckdb_1_5_0]
+changedir = integration_test_project
+deps = dbt-duckdb~=1.5.0
+commands =
+    dbt clean
+    dbt deps
+    dbt build --exclude tag:microbatch --target duckdb
+
+[testenv:integration_duckdb_1_6_0]
+changedir = integration_test_project
+deps = dbt-duckdb~=1.6.0
+commands =
+    dbt clean
+    dbt deps
+    dbt build --exclude tag:microbatch --target duckdb
+
+[testenv:integration_duckdb_1_7_0]
+changedir = integration_test_project
+deps = dbt-duckdb~=1.7.0
+commands =
+    dbt clean
+    dbt deps
+    dbt build --exclude tag:microbatch --target duckdb
+    
+[testenv:integration_duckdb_1_8_0]
+changedir = integration_test_project
+deps =
+    dbt-core~=1.8.0
+    dbt-duckdb~=1.8.0
+commands =
+    dbt clean
+    dbt deps
+    dbt build --exclude tag:microbatch --target duckdb
+
+[testenv:integration_duckdb_1_9_0]
+changedir = integration_test_project
+deps =
+    dbt-core~=1.9.0
+    dbt-duckdb~=1.9.0
+commands =
+    dbt clean
+    dbt deps
+    dbt build --exclude tag:microbatch --target duckdb
+
 [testenv:integration_sqlserver]
 changedir = integration_test_project
 deps = dbt-sqlserver~=1.8.0


### PR DESCRIPTION
## Overview

Add support for DuckDB. DuckDB SQL is the same as postgres in this case, so we can re-use the Postgres syntax and just include the macros with `duckdb__`. 

There is no microbatch support (yet) in dbt-duckdb, so microbatch models in the integration tests have a tag and this tag is excluded on the DuckDB tests.

DuckDB tests can run as files in CI, so no additional config is needed other than a new profile.

## Update type - breaking / non-breaking

<!-- What type of update is this? -->
- [ ] Minor bug fix
- [ ] Documentation improvements
- [ ] Quality of Life improvements
- [x] New features (non-breaking change)
- [ ] New features (breaking change)
- [ ] Other (non-breaking change)
- [ ] Other (breaking change)
- [ ] Release preparation

## What does this solve?

#412 

## Outstanding questions

No

## What databases have you tested with?

- [ ] Snowflake
- [ ] Google BigQuery
- [ ] Databricks
- [ ] Spark
- [x] DuckDB
- [ ] N/A
