### PR TITLE
fix: handle SampleWindow serialization (#542)

### DIFF
--- a/macros/upload_individual_datasets/upload_invocations.sql
+++ b/macros/upload_individual_datasets/upload_invocations.sql
@@ -16,6 +16,14 @@
             {%- do invocation_args_dict.update({"warn_error_options": warn_error_options}) %}
         {% endif %}
     {% endif %}
+    {# sample - returns a SampleWindow python object that's not JSON serializable #}
+    {% if "sample" in invocation_args_dict %}
+        {% if invocation_args_dict.sample is not string and invocation_args_dict.sample is not none %}
+            {% set sample_window = invocation_args_dict.sample %}
+            {% set sample_dict = {"start": sample_window.start | string, "end": sample_window.end | string} %}
+            {%- do invocation_args_dict.update({"sample": sample_dict}) %}
+        {% endif %}
+    {% endif %}
     {% set converted_invocation_args_dict = dbt_artifacts.safe_copy_mapping(invocation_args_dict) %}
 
     {{ return(adapter.dispatch("get_invocations_dml_sql", "dbt_artifacts")(converted_invocation_args_dict)) }}


### PR DESCRIPTION
## Overview

Fixes #542

When using dbt's `--sample` flag, the `SampleWindow` object in `invocation_args_dict` 
is not JSON serializable. This fix handles it the same way `warn_error_options` is 
handled - by converting it to a serializable dict before passing to `safe_copy_mapping`.

## Update type - breaking / non-breaking

- [x] Minor bug fix
- [ ] Documentation improvements
- [ ] Quality of Life improvements
- [ ] New features (non-breaking change)
- [ ] New features (breaking change)
- [ ] Other (non-breaking change)
- [ ] Other (breaking change)
- [ ] Release preparation

## What does this solve?

Fixes #542 - SampleWindow object not JSON serializable when using `--sample` flag.

The `--sample` flag (introduced in dbt for event_time based sampling) adds a 
`SampleWindow` Python object to `invocation_args_dict`. This object cannot be 
serialized to JSON, causing `upload_invocations` to fail.

## Outstanding questions

None - the fix follows the existing pattern used for `warn_error_options`.

## What databases have you tested with?

- [ ] Snowflake
- [ ] Google BigQuery
- [x] Databricks
- [ ] Spark
- [ ] N/A