### PR TITLE
Support Validate Macro Args Flag

### DIFF
--- a/macros/_macros.yml
+++ b/macros/_macros.yml
@@ -23,7 +23,7 @@ macros:
       Date: 2023-04-28
     arguments:
       - name: field_list
-        type: list[string]
+        type: list[any]
         description: |
           A list of fields to concatenate together to form the surrogate key
 
@@ -136,7 +136,7 @@ macros:
       The macro to support upload of the data to the exposures table.
     arguments:
       - name: exposures
-        type: list
+        type: list[any]
         description: |
           A list of exposure objects extracted from the dbt graph
 
@@ -149,7 +149,7 @@ macros:
       The macro to support upload of the data to the model_executions table.
     arguments:
       - name: models
-        type: list
+        type: list[any]
         description: |
           A list of model execution results objects extracted from the dbt result object
 
@@ -158,7 +158,7 @@ macros:
       The macro to support upload of the data to the models table.
     arguments:
       - name: models
-        type: list
+        type: list[any]
         description: |
           A list of test objects extracted from the dbt graph
 
@@ -167,7 +167,7 @@ macros:
       The macro to support upload of the data to the seed_executions table.
     arguments:
       - name: seeds
-        type: list
+        type: list[any]
         description: |
           A list of seed execution results objects extracted from the dbt result object
 
@@ -176,7 +176,7 @@ macros:
       The macro to support upload of the data to the seeds table.
     arguments:
       - name: seeds
-        type: list
+        type: list[any]
         description: |
           A list of seeds objects extracted from the dbt graph
 
@@ -185,7 +185,7 @@ macros:
       The macro to support upload of the data to the snapshot_executions table.
     arguments:
       - name: snapshots
-        type: list
+        type: list[any]
         description: |
           A list of snapshot execution results objects extracted from the dbt result object
 
@@ -194,7 +194,7 @@ macros:
       The macro to support upload of the data to the snapshots table.
     arguments:
       - name: snapshots
-        type: list
+        type: list[any]
         description: |
           A list of snapshots objects extracted from the dbt graph
 
@@ -203,7 +203,7 @@ macros:
       The macro to support upload of the data to the sources table.
     arguments:
       - name: sources
-        type: list
+        type: list[any]
         description: |
           A list of sources objects extracted from the dbt graph
 
@@ -212,7 +212,7 @@ macros:
       The macro to support upload of the data to the test_executions table.
     arguments:
       - name: tests
-        type: list
+        type: list[any]
         description: |
           A list of test execution results objects extracted from the dbt result object
 
@@ -221,7 +221,7 @@ macros:
       The macro to support upload of the data to the tests table.
     arguments:
       - name: tests
-        type: list
+        type: list[any]
         description: |
           A list of test objects extracted from the dbt graph
 
@@ -254,7 +254,7 @@ macros:
         description: |
           The name of the dataset to return the column names for e.g. `models`
       - name: objects_to_upload
-        type: list
+        type: list[any]
         description: |
           The objects to be used to generate the insert statement values - extracted from `get_dataset_content`
 
@@ -290,6 +290,6 @@ macros:
       The main macro called to upload the metadata into each of the source tables.
     arguments:
       - name: results
-        type: list
+        type: list[any]
         description: |
           The results object from dbt.

--- a/macros/_macros.yml
+++ b/macros/_macros.yml
@@ -23,7 +23,7 @@ macros:
       Date: 2023-04-28
     arguments:
       - name: field_list
-        type: list
+        type: list[string]
         description: |
           A list of fields to concatenate together to form the surrogate key
 
@@ -87,7 +87,7 @@ macros:
       contract for the graph nodes is prone to change without warning. This macro makes handling for these changes easier and more DRY.
     arguments:
       - name: model
-        type: Node
+        type: relation
         description: A node object from the dbt graph
   - name: update_nested_dict
     description: |
@@ -95,14 +95,14 @@ macros:
       something that can be JSON serialized.
     arguments:
       - name: dictionary
-        type: mapping
+        type: dict[str, any]
         description: A mapping object to walk through
   - name: safe_copy_mapping
     description: |
       A macro that safely copies a mapping object (dictionary), using the `update_nested_dict` macro to ensure that the types are JSON serializable.
     arguments:
       - name: dictionary
-        type: mapping
+        type: dict[str, any]
         description: A mapping object to copy
   - name: type_handler
     description: |
@@ -127,7 +127,7 @@ macros:
       pre/post conversion values.
     arguments:
       - name: dictionary
-        type: mapping
+        type: dict[str, any]
         description: A mapping object to validate
 
   ## UPLOAD INDIVIDUAL DATASETS ##

--- a/macros/_macros.yml
+++ b/macros/_macros.yml
@@ -31,7 +31,7 @@ macros:
     description: |
       Identify a relation in the graph from a relation name
     arguments:
-      - name: get_relation_name
+      - name: relation_name
         type: string
         description: |
           The name of the relation to return from the graph
@@ -264,18 +264,10 @@ macros:
       `upload_results` macro, alongside the `get_column_lists` macro to generate the column names and the
       `upload_dataset` macros to generate the data to be inserted.
     arguments:
-      - name: database_name
+      - name: dataset
         type: string
         description: |
-          The database name for the relation that the data is to be inserted into
-      - name: schema_name
-        type: string
-        description: |
-          The schema name for the relation that the data is to be inserted into
-      - name: table_name
-        type: string
-        description: |
-          The table name for the relation that the data is to be inserted into
+          The name of the dataset to return the data for e.g. `models`
       - name: fields
         type: string
         description: |


### PR DESCRIPTION
## Overview

dbt Core v1.12 and Fusion will have the flag `validate_macro_args` enabled by default. This flag is ensuring macro documentation matches with implementation. With this flag enabled prior to this PR, there would be numerous warnings related to this package not properly having the macro documentation matching with the implementation. This PR should solve that issue 

Resources:
https://docs.getdbt.com/reference/global-configs/behavior-changes?version=2.0#macro-argument-validation
https://docs.getdbt.com/reference/resource-properties/arguments?version=2.0#supported-types

## Update type - breaking / non-breaking

<!-- What type of update is this? -->
- [ ] Minor bug fix
- [ ] Documentation improvements
- [x] Quality of Life improvements
- [ ] New features (non-breaking change)
- [ ] New features (breaking change)
- [ ] Other (non-breaking change)
- [ ] Other (breaking change)
- [ ] Release preparation

## What does this solve?

#517 

## Outstanding questions

I used list[any] and dict[str, any] rather than hunting down the exact types needed. I figured this is sufficient to supress these errors and is an improvement from having an incorrect value prior

## What databases have you tested with?

<!-- You don't need to have tested with them all, but this helps us know which you have tried already -->
- [x] Snowflake
- [ ] Google BigQuery
- [ ] Databricks
- [ ] Spark
- [ ] N/A
