### PR TITLE
Add option to skip manifest uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,28 @@ vars:
   dbt_artifacts_exclude_all_results: true
 ```
 
+### Skipping manifest dataset upload
+
+By default, every invocation uploads both the execution results (`model_execution`, `seed_executions`, `test_executions`, `snapshot_executions`) and project's manifest datasets (`models`, `seeds`, `snapshots`, `sources`, `tests`, `exposures`). Because manifest datasets are re-inserted on every run, the underlying tables can grow quickly on routine or scheduled runs.
+
+The manifest datasets usually change only when the project code changes, so you can skip uploading them on routine runs and upload them only when code is merged, for example during the build step in CI.
+
+To skip manifest dataset upload, set the `dbt_artifacts_upload_manifest` variable to `false`:
+
+```yml
+# dbt_project.yml
+vars:
+  dbt_artifacts_upload_manifest: false
+```
+
+When `false`, only `invocations` and the execution datasets are uploaded. `invocations` is always uploaded regardless of this setting, as it is the parent record that execution rows reference.
+
+Override it to `true` on runs where you want the full project metadata refreshed:
+
+```sh
+dbt build --vars '{"dbt_artifacts_upload_manifest": true}'
+```
+
 ## Upgrading from 1.x to >=2.0.0
 
 If you were using the following variables:

--- a/macros/upload_results/upload_results.sql
+++ b/macros/upload_results/upload_results.sql
@@ -4,7 +4,14 @@
 
     {% if execute %}
 
-        {% set datasets_to_load = ['exposures', 'seeds', 'snapshots', 'invocations', 'sources', 'tests', 'models'] %}
+        {% set upload_manifest = var('dbt_artifacts_upload_manifest', true) %}
+
+        {% set datasets_to_load = ['invocations'] %}
+
+        {% if upload_manifest %}
+            {% set datasets_to_load = ['exposures', 'seeds', 'snapshots', 'sources', 'tests', 'models'] + datasets_to_load %}
+        {% endif %}
+
         {% if results != [] %}
             {# When executing, and results are available, then upload the results #}
             {% set datasets_to_load = ['model_executions', 'seed_executions', 'test_executions', 'snapshot_executions'] + datasets_to_load %}


### PR DESCRIPTION
## Update type - breaking / non-breaking
 
- [ ] Minor bug fix
- [x] Documentation improvements
- [ ] Quality of Life improvements
- [x] New features (non-breaking change)
- [ ] New features (breaking change)
- [ ] Other (non-breaking change)
- [ ] Other (breaking change)
- [ ] Release preparation
 
## What does this solve?
 
Adds a new `dbt_artifacts_upload_manifest` var to optionally skip manifest dataset uploads on routine runs.
 
By default, the var is `true`, so the current behavior is preserved.
 
When set to `false`, `dbt_artifacts` skips uploading manifest datasets:
 
- models
- sources
- tests
- seeds
- snapshots
- exposures
 
`invocations` and execution datasets are still uploaded.
 
This is useful for scheduled/routine runs where project metadata does not change every time, but execution results still need to be recorded.
 
## Outstanding questions
 
No outstanding questions.
 
Local integration tests were not run because Docker is not available on my machine.
 
## What databases have you tested with?
 
- [ ] Snowflake
- [ ] Google BigQuery
- [ ] Databricks
- [ ] Postgres
- [ ] Trino
- [ ] SQL Server
## Testing

- `git diff --check` passed
- `./scripts/ci/setup.sh` passed
- `./scripts/ci/test.sh trino` passed
