### PR TITLE
add transactions for inserts

### DIFF
--- a/macros/upload_results/begin_transaction.sql
+++ b/macros/upload_results/begin_transaction.sql
@@ -1,0 +1,26 @@
+{% macro begin_transaction() -%}
+
+    {{ return(adapter.dispatch('begin_transaction', 'dbt_artifacts')()) }}
+
+{%- endmacro %}
+
+{% macro default__begin_transaction() -%}
+{%- endmacro %}
+
+{% macro snowflake__begin_transaction() -%}
+
+    {% do run_query('begin transaction') %}
+
+{%- endmacro %}
+
+{% macro postgres__begin_transaction() -%}
+
+    {% do run_query('begin') %}
+
+{%- endmacro %}
+
+{% macro sqlserver__begin_transaction() -%}
+
+    {% do run_query('begin transaction') %}
+
+{%- endmacro %}

--- a/macros/upload_results/end_transaction.sql
+++ b/macros/upload_results/end_transaction.sql
@@ -1,0 +1,26 @@
+{% macro end_transaction() -%}
+
+    {{ return(adapter.dispatch('end_transaction', 'dbt_artifacts')()) }}
+
+{%- endmacro %}
+
+{% macro default__end_transaction() -%}
+{%- endmacro %}
+
+{% macro snowflake__end_transaction() -%}
+
+    {% do run_query('commit') %}
+
+{%- endmacro %}
+
+{% macro postgres__end_transaction() -%}
+
+    {% do run_query('commit') %}
+
+{%- endmacro %}
+
+{% macro sqlserver__end_transaction() -%}
+
+    {% do run_query('commit transaction') %}
+
+{%- endmacro %}

--- a/macros/upload_results/upload_results.sql
+++ b/macros/upload_results/upload_results.sql
@@ -25,6 +25,9 @@
                 {% set upload_limit = 300 if target.type == 'bigquery' else 5000 %}
             {% endif %}
 
+            {# Wrap the chunked inserts in a transaction, where the dialect supports it #}
+            {{ dbt_artifacts.begin_transaction() }}
+
             {# Loop through each chunk in turn #}
             {% for i in range(0, objects | length, upload_limit) -%}
 
@@ -41,6 +44,8 @@
 
             {# Loop the next 'chunk' #}
             {% endfor %}
+
+            {{ dbt_artifacts.end_transaction() }}
 
         {# Loop the next 'dataset' #}
         {% endfor %}


### PR DESCRIPTION

## Overview

Wraps the insert statements in a transaction so that the data cannot be queried until it is uploaded in its entirity

## Update type - breaking / non-breaking

<!-- What type of update is this? -->
- [ ] Minor bug fix
- [ ] Documentation improvements
- [X] Quality of Life improvements
- [X] New features (non-breaking change)
- [ ] New features (breaking change)
- [ ] Other (non-breaking change)
- [ ] Other (breaking change)
- [ ] Release preparation

## What does this solve?

https://github.com/brooklyn-data/dbt_artifacts/issues/564

## Outstanding questions

<!-- Include any details here of issues you found along the way, or things that still require attention -->

## What databases have you tested with?

<!-- You don't need to have tested with them all, but this helps us know which you have tried already -->
- [X] Snowflake
- [ ] Google BigQuery
- [ ] Databricks
- [ ] Spark
- [ ] N/A
