### PR TITLE
Fix MissingArgumentsPropertyInGenericTestDeprecation warning

### DIFF
--- a/models/fct_dbt__consumption_by_model.yml
+++ b/models/fct_dbt__consumption_by_model.yml
@@ -31,8 +31,9 @@ models:
     description: This model's share of the month's total SMB (0..1), a window over billing_month.
     tests:
     - dbt_artifacts.is_between:
-        min_value: 0
-        max_value: 1
+        arguments:
+          min_value: 0
+          max_value: 1
   - name: builds_per_day_avg
     description: Average successful builds per active build-day (smb_quantity / distinct_days_built).
   - name: distinct_days_built

--- a/models/fct_dbt__consumption_daily.yml
+++ b/models/fct_dbt__consumption_daily.yml
@@ -24,7 +24,8 @@ models:
     tests:
     - not_null
     - accepted_values:
-        values: ['smb', 'active_target_tables']
+        arguments:
+          values: ['smb', 'active_target_tables']
   - name: quantity
     description: Metered quantity for the day x meter (sum of the detail rows).
     tests:

--- a/models/fct_dbt__consumption_daily_detail.yml
+++ b/models/fct_dbt__consumption_daily_detail.yml
@@ -26,7 +26,8 @@ models:
     tests:
     - not_null
     - accepted_values:
-        values: ['smb', 'active_target_tables']
+        arguments:
+          values: ['smb', 'active_target_tables']
   - name: materialization
     description: >
       Model materialization for 'smb' rows; null for 'active_target_tables'

--- a/models/fct_dbt__consumption_forecast.yml
+++ b/models/fct_dbt__consumption_forecast.yml
@@ -47,7 +47,8 @@ models:
     description: month_to_date_quantity / allowance for the smb meter; null otherwise.
     tests:
     - dbt_artifacts.is_between:
-        min_value: 0
+        arguments:
+          min_value: 0
   - name: days_remaining
     description: Calendar days remaining in the month after as_of (0 for fully-elapsed months).
   - name: is_on_pace_to_exceed

--- a/models/fct_dbt__dag_bottlenecks.yml
+++ b/models/fct_dbt__dag_bottlenecks.yml
@@ -28,11 +28,13 @@ models:
     description: Sum of measured stall seconds attributed to this parent that day.
     tests:
     - dbt_artifacts.is_between:
-        min_value: 0
+        arguments:
+          min_value: 0
   - name: max_stall_seconds
     description: Largest single measured stall attributed to this parent that day.
     tests:
     - dbt_artifacts.is_between:
-        min_value: 0
+        arguments:
+          min_value: 0
   - name: invocations_observed
     description: Distinct invocations in which this parent gated at least one child that day.

--- a/models/fct_dbt__dag_bottlenecks_detail.yml
+++ b/models/fct_dbt__dag_bottlenecks_detail.yml
@@ -36,4 +36,5 @@ models:
     description: max(child_compile_started_at - parent_query_completed_at, 0) in seconds.
     tests:
     - dbt_artifacts.is_between:
-        min_value: 0
+        arguments:
+          min_value: 0

--- a/models/fct_dbt__flaky_tests.yml
+++ b/models/fct_dbt__flaky_tests.yml
@@ -30,8 +30,9 @@ models:
     description: flips / executions (0..1).
     tests:
     - dbt_artifacts.is_between:
-        min_value: 0
-        max_value: 1
+        arguments:
+          min_value: 0
+          max_value: 1
   - name: last_flip_at
     description: run_started_at of the most recent flip's pass that month (null if no flips).
   - name: is_flaky

--- a/models/fct_dbt__model_performance.yml
+++ b/models/fct_dbt__model_performance.yml
@@ -48,7 +48,8 @@ models:
     description: median_runtime / baseline_runtime; null when baseline is null or 0.
     tests:
     - dbt_artifacts.is_between:
-        min_value: 0
+        arguments:
+          min_value: 0
   - name: is_regressed
     description: >
       True when runtime_regression_ratio > regression_threshold and

--- a/models/fct_dbt__run_health_daily.yml
+++ b/models/fct_dbt__run_health_daily.yml
@@ -33,8 +33,9 @@ models:
     description: successes / (successes + failures + errors); null on days with no such executions.
     tests:
     - dbt_artifacts.is_between:
-        min_value: 0
-        max_value: 1
+        arguments:
+          min_value: 0
+          max_value: 1
   - name: total_runtime_seconds
     description: Sum of total_node_runtime across all node executions that day.
   - name: max_node_runtime_seconds

--- a/models/fct_dbt__run_health_daily_detail.yml
+++ b/models/fct_dbt__run_health_daily_detail.yml
@@ -36,8 +36,9 @@ models:
     description: successes / (successes + failures + errors) for the target.
     tests:
     - dbt_artifacts.is_between:
-        min_value: 0
-        max_value: 1
+        arguments:
+          min_value: 0
+          max_value: 1
   - name: total_runtime_seconds
     description: Sum of total_node_runtime for the target that day.
   - name: max_node_runtime_seconds


### PR DESCRIPTION
## Overview

Fix `MissingArgumentsPropertyInGenericTestDeprecation` warnings that fire when parsing dbt_artifacts models on dbt Core 1.10.5+.

## Update type - breaking / non-breaking

- [x] Minor bug fix

## What does this solve?

Resolves #567

Wraps generic test arguments under the `arguments:` property:
- 9x `dbt_artifacts.is_between` — `min_value`/`max_value` nested under `arguments:`
- 2x `accepted_values` — `values` nested under `arguments:`

The `arguments:` property is recognized by dbt Core >=1.10.5 and is required (with deprecation warning) from 1.10.8+. On older versions the property is silently ignored, so this change is fully backward-compatible with the package's existing `require-dbt-version` constraint.

## Outstanding questions

None.

## What databases have you tested with?

- [x] Snowflake
- [ ] Google BigQuery
- [ ] Databricks
- [ ] Spark
- [ ] N/A